### PR TITLE
 修复Creat-theme中favicon.ico显示问题，以及文档描述不清

### DIFF
--- a/packages/create-theme/public/template/docs/.vitepress/config.mts
+++ b/packages/create-theme/public/template/docs/.vitepress/config.mts
@@ -12,6 +12,7 @@ export default defineConfig({
   title: '@sugarat/theme',
   description: '粥里有勺糖的博客主题，基于 vitepress 实现',
   lastUpdated: true,
+  head: [['link', { rel: 'icon', href: '/favicon.ico' }]],
   themeConfig: {
     lastUpdatedText: '上次更新于',
     logo: '/logo.png',

--- a/packages/create-theme/public/template/docs/sop/style.md
+++ b/packages/create-theme/public/template/docs/sop/style.md
@@ -43,7 +43,7 @@ export default BlogTheme
   );
 }
 ```
-解除注释后，就能看到模板首页背景图发生了变化
+解除文件`index.ts` 中`import './style.scss'` 注释后，就能看到模板首页背景图发生了变化
 
 ![](https://img.cdn.sugarat.top/mdImg/MTY3Njk5MTAzODkzOQ==676991038939)
 


### PR DESCRIPTION
1.直接使用yarn create @sugarat/theme，里面的ico文件并不会显示，需要添加head。
2.在[style.md](https://theme.sugarat.top/config/style.html)中 描述不准确，补充描述.