### PR TITLE
BlogItem.vue 右侧图片样式问题

### DIFF
--- a/packages/theme/src/components/BlogItem.vue
+++ b/packages/theme/src/components/BlogItem.vue
@@ -166,7 +166,7 @@ const link = computed(() => withBase(wrapperCleanUrls(!!cleanUrls, props.route))
   margin-left: 24px;
   border-radius: 2px;
   background-repeat: no-repeat;
-  background-size: 120px 80px;
+  background-size: contain;
 }
 
 .pc-visible {
@@ -181,7 +181,7 @@ const link = computed(() => withBase(wrapperCleanUrls(!!cleanUrls, props.route))
   .cover-img {
     width: 100px;
     height: 60px;
-    background-size: 100px 60px;
+    background-size: contain;
   }
 
   .pc-visible {

--- a/packages/theme/src/components/BlogItem.vue
+++ b/packages/theme/src/components/BlogItem.vue
@@ -167,6 +167,7 @@ const link = computed(() => withBase(wrapperCleanUrls(!!cleanUrls, props.route))
   border-radius: 2px;
   background-repeat: no-repeat;
   background-size: contain;
+  background-position: center;
 }
 
 .pc-visible {

--- a/packages/theme/src/components/BlogItem.vue
+++ b/packages/theme/src/components/BlogItem.vue
@@ -183,6 +183,7 @@ const link = computed(() => withBase(wrapperCleanUrls(!!cleanUrls, props.route))
     width: 100px;
     height: 60px;
     background-size: contain;
+    background-position: center;
   }
 
   .pc-visible {


### PR DESCRIPTION
- 更新 BlogItem.vue 文件的class名为cover-img的background-size属性，原属性导致图片高度拉升
- 图示
  - 修改前
    - <img width="1080" alt="截屏2024-04-01 22 52 25" src="https://github.com/ATQQ/sugar-blog/assets/122858631/807ebfbe-fdd7-4ead-ab20-5a14163200c7">
  - 修改后
    - <img width="1080" alt="截屏2024-04-01 22 51 46" src="https://github.com/ATQQ/sugar-blog/assets/122858631/dc41ec6f-c46e-4eb4-a6f6-39d20c7b9883">



