### PR TITLE
fix(rss): support git submodule

### DIFF
--- a/packages/shared/src/fs.ts
+++ b/packages/shared/src/fs.ts
@@ -38,8 +38,15 @@ export async function getFileLastModifyTime(url: string) {
 
 export function getFileLastModifyTimeByGit(url: string): Promise<Date | undefined> {
   return new Promise((resolve) => {
+    const cwd = path.dirname(url)
+    if (!fs.existsSync(cwd))
+      return resolve(undefined)
+    const fileName = path.basename(url)
+
     // 使用异步回调
-    const child = spawn('git', ['log', '-1', '--pretty="%ai"', url])
+    const child = spawn('git', ['log', '-1', '--pretty="%ai"', fileName], {
+      cwd,
+    })
     let output = ''
     child.stdout.on('data', d => (output += String(d)))
     child.on('close', async () => {


### PR DESCRIPTION
获取 Git 时间时，进入工作目录再运行 git，这样可以获取到 submodule 中的文件的时间，可以与 VitePress 原生的保持一致：https://github.com/vuejs/vitepress/blob/8fef47848bd3418014b06eea1337b1e66e0473c6/src/node/utils/getGitTimestamp.ts#L12-L17

其他类似的写法： 
VitePress-Plugin-Git-Changelog： https://github.com/nolebase/integrations/blob/f400cdf43f782744ed05a783f51208ec07fd800d/packages/vitepress-plugin-git-changelog/src/vite/helpers.ts#L224-L251