### PR TITLE
Use pagefind.debouncedSearch()

### DIFF
--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -133,8 +133,11 @@ watch(
         : (chineseRegex.test(searchWords.value) ? chineseSearchOptimize(searchWords.value) : searchWords.value)
     // @ts-expect-error
     await window?.__pagefind__
-      ?.search?.(searchText)
+      ?.debouncedSearch?.(searchText, {}, 500)
       .then(async (pagefindSearchResult: any) => {
+        if (pagefindSearchResult === null) {
+          return
+        }
         // pagefind 搜索结果
         const pagefindResults = await Promise.all(
           pagefindSearchResult.results.map((v: any) => v.data())


### PR DESCRIPTION
This provides a much smoother search UX, as it minimizes the search queries executed in addition to leveraging preloading.

See https://pagefind.app/docs/api/#debounced-search and https://pagefind.app/docs/api/#preloading-search-terms