### PR TITLE
Fix path contain space

### DIFF
--- a/packages/vitepress-plugin-pagefind/src/node.ts
+++ b/packages/vitepress-plugin-pagefind/src/node.ts
@@ -19,7 +19,7 @@ export async function buildEnd(pagefindOps: PagefindOption, siteConfig: SiteConf
   log()
   log('=== pagefind: https://pagefind.app/ ===')
 
-  let command = `npx pagefind --site ${siteConfig.outDir}`
+  let command = `npx pagefind --site "${siteConfig.outDir}"`
 
   if (ignore.length) {
     command += ` --exclude-selectors "${ignore.join(', ')}"`


### PR DESCRIPTION
Fix when `outDir` contains spaces like `D:/My Blog` plugin will not work.