### PR TITLE
feat: 使用浏览器内置的分词 API Intl.Segmenter，而不是简单的添加空格

### DIFF
--- a/packages/vitepress-plugin-pagefind/src/node.ts
+++ b/packages/vitepress-plugin-pagefind/src/node.ts
@@ -56,8 +56,12 @@ export function getPagefindHead(base: string) {
   ]
 }
 export function chineseSearchOptimize(input: string) {
-  return input
-    .replace(/[\u4E00-\u9FA5]/g, ' $& ')
-    .replace(/\s+/g, ' ')
-    .trim()
+  const segmenter = new Intl.Segmenter('zh-CN', { granularity: 'word' })
+  const result: string[] = []
+  for (const it of segmenter.segment(input)) {
+    if (it.isWordLike) {
+      result.push(it.segment)
+    }
+  }
+  return result.join(' ')
 }


### PR DESCRIPTION
Intl.Segmenter 在 2024-04 在移动端全部可用，参考浏览器兼容性

https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter#%E6%B5%8F%E8%A7%88%E5%99%A8%E5%85%BC%E5%AE%B9%E6%80%A7

搜索结果前后对比
之前：
<img width="556" alt="image" src="https://github.com/user-attachments/assets/14a7d1c6-8425-40c0-a280-d1a7a6928a0f">
之后：
<img width="557" alt="image" src="https://github.com/user-attachments/assets/8ecbee2c-8db4-40e3-a88f-ad65ae40937d">

尽管考虑到浏览器内置的分词算法与 jieba 实现的有所不同，但仍然比粗暴的在每个中文之间添加空格效果要好得多