### PR TITLE
fix(oml2d): options not effective

### DIFF
--- a/packages/theme/src/hooks/useOml2d.ts
+++ b/packages/theme/src/hooks/useOml2d.ts
@@ -42,7 +42,7 @@ export function useOml2d() {
       const { loadOml2d } = await import('oh-my-live2d')
       loadOml2d({
         ...defaultOptions,
-        ...oml2dOptions,
+        ...oml2dOptions?.value,
         models: oml2dOptions?.value?.models?.map(model => ({
           ...defaultModelOptions,
           ...model,


### PR DESCRIPTION
修复 oml2d 的 options 配置不生效的问题。