### PR TITLE
fix: Allow partial locale overrides in RSSOptions

### DIFF
--- a/packages/vitepress-plugin-rss/README-zh.md
+++ b/packages/vitepress-plugin-rss/README-zh.md
@@ -329,7 +329,7 @@ export type RSSOptions = Omit<FeedOptions, 'id'> & {
   /**
    * 国际化支持（locale 配置未声明的字段会继承全局 RSSOptions，除 locales 本身外）
    */
-  locales?: Record<string, Omit<RSSOptions, 'locales'>>
+  locales?: Record<string, Partial<Omit<RSSOptions, 'locales'>>>
   /**
    * 是否缓存文档渲染结果
    * @default true

--- a/packages/vitepress-plugin-rss/README.md
+++ b/packages/vitepress-plugin-rss/README.md
@@ -354,7 +354,7 @@ export type RSSOptions = Omit<FeedOptions, 'id'> & {
   /**
    * i18n (locale configs inherit unspecified fields from the root/global RSSOptions; locales is not recursive)
    */
-  locales?: Record<string, Omit<RSSOptions, 'locales'>>
+  locales?: Record<string, Partial<Omit<RSSOptions, 'locales'>>>
   /**
    * Whether to cache the document rendering result
    * @default true

--- a/packages/vitepress-plugin-rss/src/type.ts
+++ b/packages/vitepress-plugin-rss/src/type.ts
@@ -89,7 +89,7 @@ export type RSSOptions = Omit<FeedOptions, 'id'> & {
   /**
    * 国际化支持（locale 配置未声明的字段会继承全局 RSSOptions，除 locales 本身外）
    */
-  locales?: Record<string, Omit<RSSOptions, 'locales'>>
+  locales?: Record<string, Partial<Omit<RSSOptions, 'locales'>>>
 
   /**
    * 是否缓存文档渲染结果


### PR DESCRIPTION
我 ide 的 ts 语言服务器坏了一个月， 刚修好，发现

<img width="872" height="213" alt="image" src="https://github.com/user-attachments/assets/15d48b75-d887-4033-8b83-70e015f71d28" />

便修复类型声明，以符合实际行为：“locale 配置未声明的字段会继承全局 RSSOption”。