### PR TITLE
chore(vite-plugin-rss): 修正语法小问题

### DIFF
--- a/packages/vitepress-plugin-rss/src/node.ts
+++ b/packages/vitepress-plugin-rss/src/node.ts
@@ -450,7 +450,7 @@ export async function genFeed(config: SiteConfig, rssOptions: RSSOptions, assets
     console.log('🎉 RSS generated', RSSFilename)
     console.log('rss filepath:', RSSFilepath)
     console.log('rss url:', normalizeUrl(`${baseUrl}${config.site.base + RSSFilename}`))
-    console.log('include', posts.length, 'posts')
+    console.log('included', posts.length, 'posts')
   }
 }
 


### PR DESCRIPTION
<img width="903" height="327" alt="image" src="https://github.com/user-attachments/assets/7c490392-8a7a-4de3-b1b9-0d138c0087ed" />

另外现在回过头来想想 `rssOptions.transform` 也许应该接受一个函数数组 `[func1, func2, ...]` 扩展性会好一些，我年底可以来做个兼容

https://github.com/ATQQ/sugar-blog/blob/fb252b2a40cc15a01f58b2a7f0c7870d8b61bcc5/packages/vitepress-plugin-rss/src/node.ts#L331-L334