### PR TITLE
feat(theme): 添加 extractDefaultExportString 函数以支持多种默认导出字符串解析

### DIFF
--- a/packages/theme/src/utils/node/vitePlugins.ts
+++ b/packages/theme/src/utils/node/vitePlugins.ts
@@ -117,6 +117,32 @@ export function patchGroupIconPlugin() {
   })
 }
 
+export function extractDefaultExportString(info: any): string | undefined {
+  // AST 优先：兼容 Literal 与无表达式的 TemplateLiteral
+  const ast: any = info.ast
+  try {
+    if (ast && Array.isArray(ast.body)) {
+      for (const node of ast.body) {
+        if (node.type === 'ExportDefaultDeclaration') {
+          const decl = node.declaration
+          if (decl?.type === 'Literal' && typeof decl.value === 'string') {
+            return decl.value
+          }
+          if (decl?.type === 'TemplateLiteral' && (decl.expressions?.length ?? 0) === 0) {
+            return decl.quasis?.[0]?.value?.cooked
+          }
+        }
+      }
+    }
+  }
+  catch (_) {
+    // 忽略 AST 解析异常，走回退
+  }
+  // 正则回退：兼容 ' " ` 三种引号与空白
+  const m = info.code?.match(/export\s+default\s+(['"`])([\s\S]*?)\1/)
+  return m?.[2]
+}
+
 export function patchTabsPlugin() {
   return createPatchPlugin({
     name: '@sugarat/theme-plugin-patch-tabs',
@@ -243,8 +269,9 @@ export function coverImgTransform() {
       if (!relativePathMap[info.id]) {
         return
       }
-      const asset = info.code?.match(/export default "(.*)"/)?.[1]
+      const asset = extractDefaultExportString(info)
       if (!asset) {
+        console.warn(`[coverImgTransform] 解析默认导出失败: ${info.id}`)
         return
       }
 


### PR DESCRIPTION
扩展封面图片转换功能，支持解析使用模板字符串或无表达式的模板字符串作为默认导出的模块。当 AST 解析失败时，使用正则表达式作为回退方案以确保兼容性，并在解析失败时输出警告日志。