### PR TITLE
fix(artalk): 修复初始化不显示并加强 Observer 生命周期

### DIFF
--- a/packages/vitepress-plugin-artalk/src/components/ArtalkComment.vue
+++ b/packages/vitepress-plugin-artalk/src/components/ArtalkComment.vue
@@ -30,8 +30,7 @@ const artalk = ref<Artalk>()
 const artalkContainer = ref<HTMLDivElement>()
 
 function initArtalk() {
-  // CDN 异步加载，有优化空间
-  const observer = new MutationObserver((mutationsList, observer) => {
+  const doInit = () => {
     // @ts-expect-error
     if (window.Artalk && commentConfig.value && artalkContainer.value) {
       // @ts-expect-error
@@ -44,11 +43,18 @@ function initArtalk() {
         site: commentConfig.value?.site,
         ...commentConfig.value
       })
-      observer.disconnect()
+      return true
     }
+    return false
+  }
+
+  if (doInit()) return
+
+  const observer = new MutationObserver(() => {
+    if (doInit()) observer.disconnect()
   })
 
-  observer.observe(document.head, { subtree: true, childList: true, attributes: true, attributeFilter: ['id'] })
+  observer.observe(document.head, { subtree: true, childList: true })
 }
 
 watch(() => route.path, () => {

--- a/packages/vitepress-plugin-artalk/src/components/ArtalkComment.vue
+++ b/packages/vitepress-plugin-artalk/src/components/ArtalkComment.vue
@@ -28,9 +28,13 @@ const commentConfig = computed(() => {
 const route = useRoute()
 const artalk = ref<Artalk>()
 const artalkContainer = ref<HTMLDivElement>()
+let artalkObserver: MutationObserver | undefined
 
 function initArtalk() {
   const doInit = () => {
+    if (artalk.value) {
+      return true
+    }
     // @ts-expect-error
     if (window.Artalk && commentConfig.value && artalkContainer.value) {
       // @ts-expect-error
@@ -50,11 +54,15 @@ function initArtalk() {
 
   if (doInit()) return
 
-  const observer = new MutationObserver(() => {
-    if (doInit()) observer.disconnect()
+  artalkObserver?.disconnect()
+  artalkObserver = new MutationObserver(() => {
+    if (doInit()) {
+      artalkObserver?.disconnect()
+      artalkObserver = undefined
+    }
   })
 
-  observer.observe(document.head, { subtree: true, childList: true })
+  artalkObserver.observe(document.head, { subtree: true, childList: true })
 }
 
 watch(() => route.path, () => {
@@ -68,6 +76,8 @@ watch(() => route.path, () => {
 })
 
 onUnmounted(() => {
+  artalkObserver?.disconnect()
+  artalkObserver = undefined
   if (artalk.value) {
     artalk.value.destroy()
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 说明

在 #437 的基础上，按 Code Review 建议补充了两处优化：

1. **防止重复初始化**：`doInit` 在 `artalk.value` 已存在时直接返回，避免极短窗口内同步路径与 `MutationObserver` 各触发一次 `Artalk.init`。
2. **卸载时断开 Observer**：保存 `MutationObserver` 引用，在初始化成功或组件 `onUnmounted` 时 `disconnect`，避免 CDN 加载失败时 Observer 长期挂起造成泄漏。

## 变更文件

- `packages/vitepress-plugin-artalk/src/components/ArtalkComment.vue`

## 相关 PR

- 包含 #437 的修复（先同步 `doInit` 再挂 Observer）
- 若 #437 已合并，本 PR 可 rebase 后仅保留第二条 commit

## 测试建议

- [x] 硬刷新 + 禁用缓存：脚本晚于组件挂载
- [x] 二次访问 / 强缓存：脚本早于 `onMounted`（#437 主要修复场景）
- [x] 离开页面后确认无残留 Observer（DevTools Performance / Memory 可选）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe8f8ba6-83ae-4b54-a2e4-794bb45ecb62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe8f8ba6-83ae-4b54-a2e4-794bb45ecb62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

