### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **pnpm monorepo** for a VitePress-based blog ecosystem. There are no automated tests (no vitest/jest). There are no databases or external services required for local development.
+
+### Services
+
+| Service | Command | Default Port |
+|---|---|---|
+| Blog dev server (blogpress) | `pnpm dev` | 5173 |
+| Theme docs dev server | `pnpm dev:theme` | 5174 (or next available) |
+
+### Key commands
+
+- **Install deps**: `pnpm install`
+- **Build libraries** (required before running dev servers): `pnpm buildlib`
+- **Lint**: `pnpm lint` (pre-existing lint errors exist in the repo; this is expected)
+- **Blog build**: `pnpm build`
+- **Theme docs build**: `pnpm buildTheme`
+
+See `package.json` root scripts and the repo README for the full command list.
+
+### Gotchas
+
+- `pnpm buildlib` may fail on a clean install due to a race condition: the `build:rss` and `build:pagefind` tasks use `wait-on packages/shared/dist` to wait for the shared package, but `.d.ts` generation may not be complete when the directory appears. If `buildlib` fails, simply re-run it and it will succeed on the second attempt since `packages/shared/dist` will already be fully populated.
+- pnpm 10+ blocks lifecycle scripts by default. The `pnpm.onlyBuiltDependencies` allowlist in `package.json` controls which packages may run install scripts. If new native dependencies are added and their postinstall scripts are blocked, they may need to be added to that allowlist.
+- The `postinstall` script runs `npx simple-git-hooks` to set up a `pre-commit` hook that runs `pnpm lint-staged` (which applies `eslint --fix`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents working on this monorepo.

### What's included

- Overview of the monorepo structure (pnpm monorepo, VitePress blog ecosystem)
- Service table with commands and ports for the blog and theme docs dev servers
- Key commands for install, build, lint, and dev
- Known gotchas: `pnpm buildlib` race condition on clean install, pnpm 10+ lifecycle script blocking, and git hooks setup

### Dev environment demo

[demo_blog_and_theme_docs.mp4](https://cursor.com/agents/bc-49e349f4-cce8-42b1-a79a-b4f816b01733/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_blog_and_theme_docs.mp4)

Blog homepage and theme docs running locally:

[Blog homepage](https://cursor.com/agents/bc-49e349f4-cce8-42b1-a79a-b4f816b01733/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_homepage.webp)
[Theme docs homepage](https://cursor.com/agents/bc-49e349f4-cce8-42b1-a79a-b4f816b01733/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme_docs_homepage.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49e349f4-cce8-42b1-a79a-b4f816b01733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49e349f4-cce8-42b1-a79a-b4f816b01733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

