### PR TITLE
chore: version bump vitepress-plugin-artalk to 0.1.2 & @sugarat/create-theme to 0.0.99

### DIFF
--- a/packages/blogpress/CHANGELOG.md
+++ b/packages/blogpress/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 我的博客内容
 
+## 2.0.81
+
+### Patch Changes
+
+- @sugarat/theme@0.5.20
+
 ## 2.0.80
 
 ### Patch Changes

--- a/packages/blogpress/package.json
+++ b/packages/blogpress/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blogpress",
   "type": "module",
-  "version": "2.0.80",
+  "version": "2.0.81",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/packages/create-theme/CHANGELOG.md
+++ b/packages/create-theme/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sugarat/create-theme
 
+## 0.0.99
+
+### Patch Changes
+
+- chore: update template theme version
+
 ## 0.0.98
 
 ### Patch Changes

--- a/packages/create-theme/package.json
+++ b/packages/create-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sugarat/create-theme",
-  "version": "0.0.98",
+  "version": "0.0.99",
   "description": "简约风的 Vitepress 博客主题，sugarat vitepress blog theme",
   "author": "粥里有勺糖",
   "license": "MIT",

--- a/packages/create-theme/public/template/package.json
+++ b/packages/create-theme/public/template/package.json
@@ -10,7 +10,7 @@
     "serve": "vitepress serve docs"
   },
   "dependencies": {
-    "@sugarat/theme": "^0.5.19"
+    "@sugarat/theme": "^0.5.20"
   },
   "directories": {
     "doc": "docs"

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sugarat/theme
 
+## 0.5.20
+
+### Patch Changes
+
+- Updated dependencies
+  - vitepress-plugin-artalk@0.1.2
+
 ## 0.5.19
 
 ### Patch Changes

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sugarat/theme",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "简约风的 Vitepress 博客主题，sugarat vitepress blog theme",
   "author": "sugar",
   "license": "MIT",

--- a/packages/vitepress-plugin-artalk/CHANGELOG.md
+++ b/packages/vitepress-plugin-artalk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # vitepress-plugin-artalk
 
+## 0.1.2
+
+### Patch Changes
+
+- fix: 修复初始化不显示评论区的bug，防止重复初始化并在卸载时断开 Observer
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/vitepress-plugin-artalk/package.json
+++ b/packages/vitepress-plugin-artalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitepress-plugin-artalk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "vitepress plugin artalk",
   "author": "sugar",
   "license": "MIT",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

使用 changesets 更新 `vitepress-plugin-artalk` 和 `@sugarat/create-theme` 版本。

## 变更内容

### vitepress-plugin-artalk `0.1.1` → `0.1.2`
- fix: 修复初始化不显示评论区的bug，防止重复初始化并在卸载时断开 Observer

### @sugarat/create-theme `0.0.98` → `0.0.99`
- chore: update template theme version

### 级联更新（`updateInternalDependencies: patch`）
- `@sugarat/theme` `0.5.19` → `0.5.20`（依赖 artalk 更新）
- `blogpress` `2.0.80` → `2.0.81`（依赖 theme 更新）
- `@sugarat/create-theme` 模板中 `@sugarat/theme` 版本更新为 `^0.5.20`

## 修改的文件

| 文件 | 变更 |
|------|------|
| `packages/vitepress-plugin-artalk/package.json` | version `0.1.1` → `0.1.2` |
| `packages/vitepress-plugin-artalk/CHANGELOG.md` | 新增 `0.1.2` changelog |
| `packages/create-theme/package.json` | version `0.0.98` → `0.0.99` |
| `packages/create-theme/CHANGELOG.md` | 新增 `0.0.99` changelog |
| `packages/theme/package.json` | version `0.5.19` → `0.5.20` |
| `packages/theme/CHANGELOG.md` | 新增 `0.5.20` changelog |
| `packages/blogpress/package.json` | version `2.0.80` → `2.0.81` |
| `packages/blogpress/CHANGELOG.md` | 新增 `2.0.81` changelog |
| `packages/create-theme/public/template/package.json` | `@sugarat/theme` → `^0.5.20` |

## 发布步骤

合并此 PR 后，运行以下命令发布到 npm：

```bash
pnpm release:only
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49e349f4-cce8-42b1-a79a-b4f816b01733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49e349f4-cce8-42b1-a79a-b4f816b01733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

