### PR TITLE
chore: version bump v0.5.21 修复 Safari/iPhone 图标不显示

### DIFF
--- a/packages/blogpress/CHANGELOG.md
+++ b/packages/blogpress/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 我的博客内容
 
+## 2.0.82
+
+### Patch Changes
+
+- Updated dependencies
+  - @sugarat/theme@0.5.21
+
 ## 2.0.81
 
 ### Patch Changes

--- a/packages/blogpress/package.json
+++ b/packages/blogpress/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blogpress",
   "type": "module",
-  "version": "2.0.81",
+  "version": "2.0.82",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/packages/create-theme/CHANGELOG.md
+++ b/packages/create-theme/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sugarat/create-theme
 
+## 0.0.100
+
+### Patch Changes
+
+- chore: update template theme version
+
 ## 0.0.99
 
 ### Patch Changes

--- a/packages/create-theme/package.json
+++ b/packages/create-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sugarat/create-theme",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "description": "简约风的 Vitepress 博客主题，sugarat vitepress blog theme",
   "author": "粥里有勺糖",
   "license": "MIT",

--- a/packages/create-theme/public/template/package.json
+++ b/packages/create-theme/public/template/package.json
@@ -10,7 +10,7 @@
     "serve": "vitepress serve docs"
   },
   "dependencies": {
-    "@sugarat/theme": "^0.5.20"
+    "@sugarat/theme": "^0.5.21"
   },
   "directories": {
     "doc": "docs"

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -5,11 +5,6 @@
 ### Patch Changes
 
 - fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
-
-  - 文章页元信息图标（作者、时间、字数、阅读时间、标签）在 Safari 上不可见
-  - Icon 组件及各插件统一为 v-html / slot 注入的 SVG 补充尺寸约束
-  - 作品页、返回顶部、赞赏按钮等场景同步修复
-
 - Updated dependencies
   - vitepress-plugin-back2top@0.1.2
   - vitepress-plugin-giscus@0.1.2

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @sugarat/theme
 
+## 0.5.21
+
+### Patch Changes
+
+- fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
+
+  - 文章页元信息图标（作者、时间、字数、阅读时间、标签）在 Safari 上不可见
+  - Icon 组件及各插件统一为 v-html / slot 注入的 SVG 补充尺寸约束
+  - 作品页、返回顶部、赞赏按钮等场景同步修复
+
+- Updated dependencies
+  - vitepress-plugin-back2top@0.1.2
+  - vitepress-plugin-giscus@0.1.2
+  - vitepress-plugin-artalk@0.1.3
+  - vitepress-plugin-announcement@0.1.9
+
 ## 0.5.20
 
 ### Patch Changes

--- a/packages/theme/docs/changelog.md
+++ b/packages/theme/docs/changelog.md
@@ -1,6 +1,6 @@
 ---
 title: 更新日志
-description: 最近更新（v0.5.19） ⏰ 2026/04/26：依赖更新
+description: 最近更新（v0.5.21） ⏰ 2026/06/05：修复 Safari/iPhone 图标不显示
 author: 粥里有勺糖
 top: 3
 tag: 日志
@@ -26,6 +26,36 @@ bun update @sugarat/theme
 bun install vitepress@latest
 ```
 :::
+
+## 0.5.21 (2026/06/05)
+
+### Patch Changes
+
+- fix: 修复 Safari / WebKit（iPhone）下图标不显示的问题 ([#441](https://github.com/ATQQ/sugar-blog/issues/441))
+
+  **问题表现**：文章页元信息区域的图标（作者、发布时间、字数、阅读时间、标签等）在 iPhone / Safari 上不可见，桌面端浏览器显示正常。
+
+  **影响范围**：
+  - 文章页元信息（`BlogArticleAnalyze`）
+  - 作品页时间 / 链接 / 标签图标（`UserWorks`）
+  - 返回顶部按钮默认图标（`BlogBackToTop`）
+  - 文章底部赞赏按钮图标（`BlogButtonAfterArticle`）
+  - 评论区、公告、回到顶部等插件的 `Icon` 组件
+
+  **修复方式**：为 flex 布局中的 SVG 补充明确的 `width` / `height` 尺寸约束，避免 WebKit 将无尺寸 SVG 渲染为 0 大小。
+
+- Updated dependencies
+  - vitepress-plugin-back2top@0.1.2
+  - vitepress-plugin-giscus@0.1.2
+  - vitepress-plugin-artalk@0.1.3
+  - vitepress-plugin-announcement@0.1.9
+
+## 0.5.20 (2026/05/20)
+
+### Patch Changes
+
+- Updated dependencies
+  - vitepress-plugin-artalk@0.1.2
 
 ## 0.5.19 (2026/04/26)
 

--- a/packages/theme/docs/changelog.md
+++ b/packages/theme/docs/changelog.md
@@ -31,19 +31,7 @@ bun install vitepress@latest
 
 ### Patch Changes
 
-- fix: 修复 Safari / WebKit（iPhone）下图标不显示的问题 ([#441](https://github.com/ATQQ/sugar-blog/issues/441))
-
-  **问题表现**：文章页元信息区域的图标（作者、发布时间、字数、阅读时间、标签等）在 iPhone / Safari 上不可见，桌面端浏览器显示正常。
-
-  **影响范围**：
-  - 文章页元信息（`BlogArticleAnalyze`）
-  - 作品页时间 / 链接 / 标签图标（`UserWorks`）
-  - 返回顶部按钮默认图标（`BlogBackToTop`）
-  - 文章底部赞赏按钮图标（`BlogButtonAfterArticle`）
-  - 评论区、公告、回到顶部等插件的 `Icon` 组件
-
-  **修复方式**：为 flex 布局中的 SVG 补充明确的 `width` / `height` 尺寸约束，避免 WebKit 将无尺寸 SVG 渲染为 0 大小。
-
+- fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
 - Updated dependencies
   - vitepress-plugin-back2top@0.1.2
   - vitepress-plugin-giscus@0.1.2

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sugarat/theme",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "description": "简约风的 Vitepress 博客主题，sugarat vitepress blog theme",
   "author": "sugar",
   "license": "MIT",

--- a/packages/vitepress-plugin-announcement/CHANGELOG.md
+++ b/packages/vitepress-plugin-announcement/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
 
-  - 文章页元信息图标（作者、时间、字数、阅读时间、标签）在 Safari 上不可见
-  - Icon 组件及各插件统一为 v-html / slot 注入的 SVG 补充尺寸约束
-  - 作品页、返回顶部、赞赏按钮等场景同步修复
-
 ## 0.1.8
 
 ### Patch Changes

--- a/packages/vitepress-plugin-announcement/CHANGELOG.md
+++ b/packages/vitepress-plugin-announcement/CHANGELOG.md
@@ -1,5 +1,15 @@
 # vitepress-plugin-announcement
 
+## 0.1.9
+
+### Patch Changes
+
+- fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
+
+  - 文章页元信息图标（作者、时间、字数、阅读时间、标签）在 Safari 上不可见
+  - Icon 组件及各插件统一为 v-html / slot 注入的 SVG 补充尺寸约束
+  - 作品页、返回顶部、赞赏按钮等场景同步修复
+
 ## 0.1.8
 
 ### Patch Changes

--- a/packages/vitepress-plugin-announcement/package.json
+++ b/packages/vitepress-plugin-announcement/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitepress-plugin-announcement",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "vitepress plugin, Announcement, 公告窗口",
   "author": "sugar",
   "license": "MIT",

--- a/packages/vitepress-plugin-artalk/CHANGELOG.md
+++ b/packages/vitepress-plugin-artalk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # vitepress-plugin-artalk
 
+## 0.1.3
+
+### Patch Changes
+
+- fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
+
+  - 文章页元信息图标（作者、时间、字数、阅读时间、标签）在 Safari 上不可见
+  - Icon 组件及各插件统一为 v-html / slot 注入的 SVG 补充尺寸约束
+  - 作品页、返回顶部、赞赏按钮等场景同步修复
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/vitepress-plugin-artalk/CHANGELOG.md
+++ b/packages/vitepress-plugin-artalk/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
 
-  - 文章页元信息图标（作者、时间、字数、阅读时间、标签）在 Safari 上不可见
-  - Icon 组件及各插件统一为 v-html / slot 注入的 SVG 补充尺寸约束
-  - 作品页、返回顶部、赞赏按钮等场景同步修复
-
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/vitepress-plugin-artalk/package.json
+++ b/packages/vitepress-plugin-artalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitepress-plugin-artalk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "vitepress plugin artalk",
   "author": "sugar",
   "license": "MIT",

--- a/packages/vitepress-plugin-back2top/CHANGELOG.md
+++ b/packages/vitepress-plugin-back2top/CHANGELOG.md
@@ -1,5 +1,15 @@
 # vitepress-plugin-back2top
 
+## 0.1.2
+
+### Patch Changes
+
+- fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
+
+  - 文章页元信息图标（作者、时间、字数、阅读时间、标签）在 Safari 上不可见
+  - Icon 组件及各插件统一为 v-html / slot 注入的 SVG 补充尺寸约束
+  - 作品页、返回顶部、赞赏按钮等场景同步修复
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/vitepress-plugin-back2top/CHANGELOG.md
+++ b/packages/vitepress-plugin-back2top/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
 
-  - 文章页元信息图标（作者、时间、字数、阅读时间、标签）在 Safari 上不可见
-  - Icon 组件及各插件统一为 v-html / slot 注入的 SVG 补充尺寸约束
-  - 作品页、返回顶部、赞赏按钮等场景同步修复
-
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/vitepress-plugin-back2top/package.json
+++ b/packages/vitepress-plugin-back2top/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitepress-plugin-back2top",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "vitepress plugin back to top",
   "author": "sugar",
   "license": "MIT",

--- a/packages/vitepress-plugin-giscus/CHANGELOG.md
+++ b/packages/vitepress-plugin-giscus/CHANGELOG.md
@@ -1,5 +1,15 @@
 # vitepress-plugin-giscus
 
+## 0.1.2
+
+### Patch Changes
+
+- fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
+
+  - 文章页元信息图标（作者、时间、字数、阅读时间、标签）在 Safari 上不可见
+  - Icon 组件及各插件统一为 v-html / slot 注入的 SVG 补充尺寸约束
+  - 作品页、返回顶部、赞赏按钮等场景同步修复
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/vitepress-plugin-giscus/CHANGELOG.md
+++ b/packages/vitepress-plugin-giscus/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - fix: 修复 Safari/WebKit（iPhone）下图标不显示的问题
 
-  - 文章页元信息图标（作者、时间、字数、阅读时间、标签）在 Safari 上不可见
-  - Icon 组件及各插件统一为 v-html / slot 注入的 SVG 补充尺寸约束
-  - 作品页、返回顶部、赞赏按钮等场景同步修复
-
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/vitepress-plugin-giscus/package.json
+++ b/packages/vitepress-plugin-giscus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitepress-plugin-giscus",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "vitepress plugin giscus",
   "author": "sugar",
   "license": "MIT",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 版本升级

| 包 | 版本 |
|---|---|
| `@sugarat/theme` | 0.5.20 → **0.5.21** |
| `@sugarat/create-theme` | 0.0.99 → **0.0.100** |
| `vitepress-plugin-back2top` | 0.1.1 → **0.1.2** |
| `vitepress-plugin-giscus` | 0.1.1 → **0.1.2** |
| `vitepress-plugin-artalk` | 0.1.2 → **0.1.3** |
| `vitepress-plugin-announcement` | 0.1.8 → **0.1.9** |
| `blogpress` | 2.0.81 → **2.0.82**（级联） |

## Changelog

- 各包 changelog 仅保留总结性标题，移除冗余细节
- `packages/theme/docs/changelog.md` 已同步更新
- `create-theme` 模板依赖已更新为 `@sugarat/theme@^0.5.21`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-601432ce-8799-40aa-b7a1-d1c24372b074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-601432ce-8799-40aa-b7a1-d1c24372b074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

