### PR TITLE
fix: stabilize theme hydration for dates and friend links

### DIFF
--- a/packages/theme/src/components/BlogFriendLink.vue
+++ b/packages/theme/src/components/BlogFriendLink.vue
@@ -45,6 +45,7 @@ const currentIndex = ref(0)
 const isTransitioning = ref(false)
 const isPageVisible = ref(true)
 const isImageDark = computed(() => isMounted.value && isDark.value)
+let resetTimer: ReturnType<typeof setTimeout> | undefined
 
 function refreshRandomFriendList() {
   currentIndex.value = 0
@@ -109,6 +110,13 @@ function resetScrollState() {
   isTransitioning.value = false
 }
 
+function clearResetTimer() {
+  if (resetTimer) {
+    clearTimeout(resetTimer)
+    resetTimer = undefined
+  }
+}
+
 function getFriendKey(item: FriendListItem, idx: number) {
   const key = `${item.url}-${item.nickname}`
   const cloneIndex = idx - friendList.value.length
@@ -116,14 +124,23 @@ function getFriendKey(item: FriendListItem, idx: number) {
 }
 
 const { resume, pause } = useIntervalFn(() => {
+  if (resetTimer)
+    return
+
   if (!openScroll.value)
     return
+
+  if (currentIndex.value > friendList.value.length) {
+    resetScrollState()
+  }
 
   currentIndex.value++
   isTransitioning.value = true
 
   if (currentIndex.value === friendList.value.length) {
-    setTimeout(() => {
+    clearResetTimer()
+    resetTimer = setTimeout(() => {
+      resetTimer = undefined
       isTransitioning.value = false
       currentIndex.value = 0
     }, 500)
@@ -134,6 +151,9 @@ const { resume, pause } = useIntervalFn(() => {
 
 function syncScrollState() {
   if (openScroll.value && isPageVisible.value) {
+    if (currentIndex.value > friendList.value.length) {
+      resetScrollState()
+    }
     resume()
   }
   else {
@@ -141,6 +161,7 @@ function syncScrollState() {
   }
 
   if (!openScroll.value) {
+    clearResetTimer()
     resetScrollState()
   }
 }
@@ -169,6 +190,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  clearResetTimer()
   pause()
   document.removeEventListener('visibilitychange', handleVisibilityChange)
 })

--- a/packages/theme/src/components/BlogFriendLink.vue
+++ b/packages/theme/src/components/BlogFriendLink.vue
@@ -2,10 +2,15 @@
 import { useDark, useIntervalFn } from '@vueuse/core'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useFriendData } from '../composables/config/blog'
-import { getImageUrl } from '../utils/client'
+import { getImageUrl, shuffleArray } from '../utils/client'
 import type { Theme } from '../'
 import { friendLinkSvgStr } from '../constants/svg'
 import Avatar from './Avatar.vue'
+
+type FriendListItem = Theme.FriendLink & {
+  avatar: string
+  alt: string
+}
 
 const isDark = useDark({
   storageKey: 'vitepress-theme-appearance'
@@ -34,12 +39,25 @@ const openScroll = computed(() => {
   return scrollSpeed.value > 0 && limit.value < friendConfig.value.list.length
 })
 
-const friendList = computed(() => {
-  const data = [...friendConfig.value.list]
-  // 简单的随机打乱，在数据导入侧打乱，避免SSG与CSR内容不一致
-  // if (friendConfig.value.random) {
-  //   data.splice(0, data.length, ...shuffleArray(data))
-  // }
+const isMounted = ref(false)
+const randomFriendList = ref<Theme.FriendLink[]>([])
+const currentIndex = ref(0)
+const isTransitioning = ref(false)
+const isImageDark = computed(() => isMounted.value && isDark.value)
+
+function refreshRandomFriendList() {
+  currentIndex.value = 0
+  isTransitioning.value = false
+  randomFriendList.value = friendConfig.value.random
+    ? shuffleArray(friendConfig.value.list)
+    : []
+}
+
+const friendList = computed<FriendListItem[]>(() => {
+  const source = isMounted.value && friendConfig.value.random
+    ? randomFriendList.value
+    : friendConfig.value.list
+  const data = [...source]
 
   // 展示个数限制，删除多余的
   if (scrollSpeed.value === 0 && limit.value) {
@@ -47,7 +65,7 @@ const friendList = computed(() => {
   }
   const list = data.map((v) => {
     const { avatar, nickname } = v
-    const avatarUrl = getImageUrl(avatar, isDark.value)
+    const avatarUrl = getImageUrl(avatar, isImageDark.value)
     let alt = nickname
     if (typeof avatar !== 'string') {
       alt = avatar.alt || ''
@@ -70,9 +88,6 @@ const containerHeight = computed(() => {
   return scrollWrapperHeight.value ? `${scrollWrapperHeight.value}px` : 'auto'
 })
 
-const currentIndex = ref(0)
-const isTransitioning = ref(false)
-
 const displayList = computed(() => {
   if (openScroll.value) {
     return [...friendList.value, ...friendList.value.slice(0, limit.value)]
@@ -87,6 +102,12 @@ const listStyle = computed(() => {
     transition: isTransitioning.value ? 'transform 0.5s ease-in-out' : 'none'
   }
 })
+
+function getFriendKey(item: FriendListItem, idx: number) {
+  const key = `${item.url}-${item.nickname}`
+  const cloneIndex = idx - friendList.value.length
+  return cloneIndex >= 0 ? `${key}-clone-${cloneIndex}` : key
+}
 
 const { resume, pause } = useIntervalFn(() => {
   if (!openScroll.value)
@@ -114,7 +135,17 @@ watch(openScroll, (val) => {
   }
 })
 
+watch(() => [friendConfig.value.list, friendConfig.value.random], () => {
+  if (isMounted.value) {
+    refreshRandomFriendList()
+  }
+}, {
+  deep: true
+})
+
 onMounted(() => {
+  isMounted.value = true
+  refreshRandomFriendList()
   if (openScroll.value)
     resume()
 })
@@ -137,7 +168,7 @@ onUnmounted(() => {
       }"
     >
       <ol class="friend-list" :style="listStyle">
-        <li v-for="(v, idx) in displayList" :key="idx" class="scroll-item">
+        <li v-for="(v, idx) in displayList" :key="getFriendKey(v, idx)" class="scroll-item">
           <a :href="v.url" target="_blank">
             <Avatar :size="50" :src="v.avatar" :alt="v.alt" />
             <div class="info-wrapper">

--- a/packages/theme/src/components/BlogFriendLink.vue
+++ b/packages/theme/src/components/BlogFriendLink.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { useDark, useIntervalFn } from '@vueuse/core'
+import { useDark } from '@vueuse/core'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useFriendData } from '../composables/config/blog'
 import { getImageUrl, shuffleArray } from '../utils/client'
@@ -45,7 +45,10 @@ const currentIndex = ref(0)
 const isTransitioning = ref(false)
 const isPageVisible = ref(true)
 const isImageDark = computed(() => isMounted.value && isDark.value)
-let resetTimer: ReturnType<typeof setTimeout> | undefined
+let scrollFrameId: number | undefined
+let lastScrollTime = 0
+let resetStartTime: number | undefined
+const transitionDuration = 500
 
 function refreshRandomFriendList() {
   currentIndex.value = 0
@@ -108,13 +111,8 @@ const listStyle = computed(() => {
 function resetScrollState() {
   currentIndex.value = 0
   isTransitioning.value = false
-}
-
-function clearResetTimer() {
-  if (resetTimer) {
-    clearTimeout(resetTimer)
-    resetTimer = undefined
-  }
+  resetStartTime = undefined
+  lastScrollTime = 0
 }
 
 function getFriendKey(item: FriendListItem, idx: number) {
@@ -123,45 +121,74 @@ function getFriendKey(item: FriendListItem, idx: number) {
   return cloneIndex >= 0 ? `${key}-clone-${cloneIndex}` : key
 }
 
-const { resume, pause } = useIntervalFn(() => {
-  if (resetTimer)
+function stopScrollLoop() {
+  if (scrollFrameId !== undefined) {
+    cancelAnimationFrame(scrollFrameId)
+    scrollFrameId = undefined
+  }
+  lastScrollTime = 0
+}
+
+function requestScrollFrame() {
+  if (scrollFrameId === undefined) {
+    scrollFrameId = requestAnimationFrame(handleScrollFrame)
+  }
+}
+
+function handleScrollFrame(timestamp: number) {
+  scrollFrameId = undefined
+
+  if (!openScroll.value || !isPageVisible.value)
     return
 
-  if (!openScroll.value)
+  if (resetStartTime !== undefined) {
+    if (timestamp - resetStartTime >= transitionDuration) {
+      resetStartTime = undefined
+      isTransitioning.value = false
+      currentIndex.value = 0
+      lastScrollTime = timestamp
+    }
+    requestScrollFrame()
     return
+  }
 
   if (currentIndex.value > friendList.value.length) {
     resetScrollState()
   }
 
-  currentIndex.value++
-  isTransitioning.value = true
-
-  if (currentIndex.value === friendList.value.length) {
-    clearResetTimer()
-    resetTimer = setTimeout(() => {
-      resetTimer = undefined
-      isTransitioning.value = false
-      currentIndex.value = 0
-    }, 500)
+  if (!lastScrollTime) {
+    lastScrollTime = timestamp
   }
-}, scrollSpeed, {
-  immediate: false
-})
+
+  if (timestamp - lastScrollTime >= scrollSpeed.value) {
+    currentIndex.value++
+    isTransitioning.value = true
+    lastScrollTime = timestamp
+
+    if (currentIndex.value === friendList.value.length) {
+      resetStartTime = timestamp
+    }
+  }
+
+  requestScrollFrame()
+}
+
+function startScrollLoop() {
+  requestScrollFrame()
+}
 
 function syncScrollState() {
   if (openScroll.value && isPageVisible.value) {
     if (currentIndex.value > friendList.value.length) {
       resetScrollState()
     }
-    resume()
+    startScrollLoop()
   }
   else {
-    pause()
+    stopScrollLoop()
   }
 
   if (!openScroll.value) {
-    clearResetTimer()
     resetScrollState()
   }
 }
@@ -190,8 +217,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  clearResetTimer()
-  pause()
+  stopScrollLoop()
   document.removeEventListener('visibilitychange', handleVisibilityChange)
 })
 </script>

--- a/packages/theme/src/components/BlogFriendLink.vue
+++ b/packages/theme/src/components/BlogFriendLink.vue
@@ -43,6 +43,7 @@ const isMounted = ref(false)
 const randomFriendList = ref<Theme.FriendLink[]>([])
 const currentIndex = ref(0)
 const isTransitioning = ref(false)
+const isPageVisible = ref(true)
 const isImageDark = computed(() => isMounted.value && isDark.value)
 
 function refreshRandomFriendList() {
@@ -103,6 +104,11 @@ const listStyle = computed(() => {
   }
 })
 
+function resetScrollState() {
+  currentIndex.value = 0
+  isTransitioning.value = false
+}
+
 function getFriendKey(item: FriendListItem, idx: number) {
   const key = `${item.url}-${item.nickname}`
   const cloneIndex = idx - friendList.value.length
@@ -122,18 +128,29 @@ const { resume, pause } = useIntervalFn(() => {
       currentIndex.value = 0
     }, 500)
   }
-}, scrollSpeed)
+}, scrollSpeed, {
+  immediate: false
+})
 
-watch(openScroll, (val) => {
-  if (val) {
+function syncScrollState() {
+  if (openScroll.value && isPageVisible.value) {
     resume()
   }
   else {
     pause()
-    currentIndex.value = 0
-    isTransitioning.value = false
   }
-})
+
+  if (!openScroll.value) {
+    resetScrollState()
+  }
+}
+
+function handleVisibilityChange() {
+  isPageVisible.value = !document.hidden
+  syncScrollState()
+}
+
+watch(openScroll, syncScrollState)
 
 watch(() => [friendConfig.value.list, friendConfig.value.random], () => {
   if (isMounted.value) {
@@ -145,13 +162,15 @@ watch(() => [friendConfig.value.list, friendConfig.value.random], () => {
 
 onMounted(() => {
   isMounted.value = true
+  isPageVisible.value = !document.hidden
   refreshRandomFriendList()
-  if (openScroll.value)
-    resume()
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+  syncScrollState()
 })
 
 onUnmounted(() => {
   pause()
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
 })
 </script>
 

--- a/packages/theme/src/components/BlogItem.vue
+++ b/packages/theme/src/components/BlogItem.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { useRouter, withBase } from 'vitepress'
-import { computed } from 'vue'
-import { wrapperCleanUrls } from '../utils/client'
+import { computed, onMounted, ref } from 'vue'
+import { formatDate, wrapperCleanUrls } from '../utils/client'
 import { useCleanUrls, useFormatShowDate, useImageStyle } from '../composables/config/blog'
 
 const props = defineProps<{
@@ -18,9 +18,19 @@ const props = defineProps<{
 }>()
 
 const formatShowDate = useFormatShowDate()
+const isMounted = ref(false)
 
 const showTime = computed(() => {
+  if (!isMounted.value) {
+    return formatDate(props.date, 'yyyy-MM-dd')
+  }
   return formatShowDate.value(props.date)
+})
+
+onMounted(() => {
+  requestAnimationFrame(() => {
+    isMounted.value = true
+  })
 })
 const cleanUrls = useCleanUrls()
 const link = computed(() => withBase(wrapperCleanUrls(!!cleanUrls, props.route)))
@@ -95,7 +105,7 @@ const resultCover = computed(() => {
         <!-- 底部补充描述 -->
         <div class="badge-list pc-visible">
           <span v-show="author" class="split">{{ author }}</span>
-          <span class="split">{{ showTime }}</span>
+          <span class="split show-time" :class="{ 'show-time-ready': isMounted }">{{ showTime }}</span>
           <span v-if="tag?.length" class="split">{{ tag?.join(' · ') }}</span>
         </div>
       </div>
@@ -105,7 +115,7 @@ const resultCover = computed(() => {
     <!-- 底部补充描述 -->
     <div class="badge-list mobile-visible">
       <span v-show="author" class="split">{{ author }}</span>
-      <span class="split">{{ showTime }}</span>
+      <span class="split show-time" :class="{ 'show-time-ready': isMounted }">{{ showTime }}</span>
       <span v-if="tag?.length" class="split">{{ tag?.join(' · ') }}</span>
     </div>
   </a>
@@ -194,6 +204,16 @@ const resultCover = computed(() => {
   font-size: 13px;
   color: var(--badge-font-color);
   margin-top: 8px;
+}
+.badge-list .show-time {
+  display: inline-block;
+  min-width: 5.5em;
+  opacity: 0.82;
+  font-variant-numeric: tabular-nums;
+  transition: opacity 0.2s ease;
+}
+.badge-list .show-time-ready {
+  opacity: 1;
 }
 .badge-list .split:not(:last-child)::after {
   content: "";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Render blog item dates as stable absolute dates during SSR/hydration, then update to configured formatted dates after mount.
- Restore friend-link randomization only after client mount, with stable item keys to avoid hydration mismatches.
- Drive friend-link auto-scroll with `requestAnimationFrame`, so background tabs naturally stop frames and visible tabs resume scrolling.
- Add a small time-text width/opacity treatment to reduce visible layout flicker when relative dates replace absolute dates.

## Testing

- `pnpm buildlib` passed.
- `pnpm buildTheme` passed.
- `pnpm exec eslint packages/theme/src/components/BlogItem.vue packages/theme/src/components/BlogFriendLink.vue` passed.
- `pnpm exec eslint packages/theme/src/components/BlogFriendLink.vue` passed after the RAF follow-up.
- `pnpm lint` still fails on existing unrelated repository lint issues; no matches for the modified files in the lint output.
- Manual browser validation on `pnpm dev:theme -- --host 0.0.0.0` confirmed blog times and friend links render after refresh with no Vue hydration mismatch warnings in DevTools Console.
- Manual browser validation with temporary local friend-link config (`limit: 1`, `scrollSpeed: 500`) confirmed foreground scrolling and resume after switching away and back; the temporary config was reverted before commit.

[theme_hydration_stability_demo.mp4](https://cursor.com/agents/bc-bdadaee2-921d-41ab-92b8-5ac9ae4eebe1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme_hydration_stability_demo.mp4)

[Blog times visible](https://cursor.com/agents/bc-bdadaee2-921d-41ab-92b8-5ac9ae4eebe1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme_blog_times.webp)
[Console without hydration warnings](https://cursor.com/agents/bc-bdadaee2-921d-41ab-92b8-5ac9ae4eebe1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme_console_no_hydration.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdadaee2-921d-41ab-92b8-5ac9ae4eebe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdadaee2-921d-41ab-92b8-5ac9ae4eebe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

