### PR TITLE
feat: 更新pagefind插件以及少量修复

### DIFF
--- a/packages/vitepress-plugin-artalk/src/components/ArtalkComment.vue
+++ b/packages/vitepress-plugin-artalk/src/components/ArtalkComment.vue
@@ -222,16 +222,28 @@ html.dark .comment-btn-wrapper {
   transition-duration: 0.3s;
 }
 
-@supports (backdrop-filter: blur(3px)) {
+/**
+ * 若要实现 `backdrop-filter: blur()`，不能使用 opacity 来控制不透明度，否则背景的模糊也会被显示出来。
+ * 因此必须固定 `opacity: 1`。然后只能通过控制更改按钮的背景色和前景色来设置颜色。
+ * 为保证颜色与用户自定义的品牌颜色匹配，需要用到相对颜色语法来计算特定颜色。
+ * 若浏览器已支持相对颜色语法特性，此时也一定支持 `backdrop-filter` 属性和 `oklch()` 颜色空间，无需特意额外声明检查支持性。
+ */
+@supports (color: rgb(from red r g b / 1)) {
   .comment-btn-wrapper {
     opacity: 1;
-    --box-shadow-color: rgba(0, 0, 0, 0.06);
+    --box-shadow-color: oklch(from var(--vp-c-brand-1) calc(l / 2.5) c h / calc(alpha * 0.08));
+    --box-shadow-hover-color: oklch(from var(--vp-c-brand-1) calc(l / 2.5) c h / calc(alpha * 0.2));
   }
   html.dark .comment-btn-wrapper {
-    --box-shadow-color: rgba(0, 0, 0, 0.36);
+    --box-shadow-color: oklch(from var(--vp-c-brand-1) calc(l / 2.5) c h / calc(alpha * 0.2));
+    --box-shadow-hover-color: oklch(from var(--vp-c-brand-1) calc(l / 5) c h / calc(alpha * 0.7));
   }
   .comment-btn-wrapper :is(.icon-wrapper, .icon-wrapper-text) {
     backdrop-filter: blur(3px);
+  }
+  .comment-btn-wrapper :is(.icon-wrapper, .icon-wrapper-text):not(:hover):not(:active) {
+    background-color: rgb(from var(--vp-c-brand-soft) r g b / calc(alpha * 0.6));
+    color: rgb(from var(--vp-c-brand-1) r g b / calc(alpha * 0.6));
   }
 }
 

--- a/packages/vitepress-plugin-back2top/src/components/BackToTop.vue
+++ b/packages/vitepress-plugin-back2top/src/components/BackToTop.vue
@@ -126,16 +126,28 @@ html.dark .back-to-top {
   transition-duration: 0.3s;
 }
 
-@supports (backdrop-filter: blur(3px)) {
+/**
+ * 若要实现 `backdrop-filter: blur()`，不能使用 opacity 来控制不透明度，否则背景的模糊也会被显示出来。
+ * 因此必须固定 `opacity: 1`。然后只能通过控制更改按钮的背景色和前景色来设置颜色。
+ * 为保证颜色与用户自定义的品牌颜色匹配，需要用到相对颜色语法来计算特定颜色。
+ * 若浏览器已支持相对颜色语法特性，此时也一定支持 `backdrop-filter` 属性和 `oklch()` 颜色空间，无需特意额外声明检查支持性。
+ */
+@supports (color: rgb(from red r g b / 1)) {
   .back-to-top {
     opacity: 1;
-    --box-shadow-color: rgba(0, 0, 0, 0.06);
+    --box-shadow-color: oklch(from var(--vp-c-brand-1) calc(l / 2.5) c h / calc(alpha * 0.08));
+    --box-shadow-hover-color: oklch(from var(--vp-c-brand-1) calc(l / 2.5) c h / calc(alpha * 0.2));
   }
   html.dark .back-to-top {
-    --box-shadow-color: rgba(0, 0, 0, 0.36);
+    --box-shadow-color: oklch(from var(--vp-c-brand-1) calc(l / 2.5) c h / calc(alpha * 0.2));
+    --box-shadow-hover-color: oklch(from var(--vp-c-brand-1) calc(l / 5) c h / calc(alpha * 0.7));
   }
   .back-to-top .icon-wrapper {
     backdrop-filter: blur(3px);
+  }
+  .back-to-top .icon-wrapper:not(:hover):not(:active) {
+    background-color: rgb(from var(--vp-c-brand-soft) r g b / calc(alpha * 0.6));
+    color: rgb(from var(--vp-c-brand-1) r g b / calc(alpha * 0.6));
   }
 }
 

--- a/packages/vitepress-plugin-giscus/src/components/GiscusComment.vue
+++ b/packages/vitepress-plugin-giscus/src/components/GiscusComment.vue
@@ -182,16 +182,28 @@ html.dark .comment-btn-wrapper {
   transition-duration: 0.3s;
 }
 
-@supports (backdrop-filter: blur(3px)) {
+/**
+ * 若要实现 `backdrop-filter: blur()`，不能使用 opacity 来控制不透明度，否则背景的模糊也会被显示出来。
+ * 因此必须固定 `opacity: 1`。然后只能通过控制更改按钮的背景色和前景色来设置颜色。
+ * 为保证颜色与用户自定义的品牌颜色匹配，需要用到相对颜色语法来计算特定颜色。
+ * 若浏览器已支持相对颜色语法特性，此时也一定支持 `backdrop-filter` 属性和 `oklch()` 颜色空间，无需特意额外声明检查支持性。
+ */
+@supports (color: rgb(from red r g b / 1)) {
   .comment-btn-wrapper {
     opacity: 1;
-    --box-shadow-color: rgba(0, 0, 0, 0.06);
+    --box-shadow-color: oklch(from var(--vp-c-brand-1) calc(l / 2.5) c h / calc(alpha * 0.08));
+    --box-shadow-hover-color: oklch(from var(--vp-c-brand-1) calc(l / 2.5) c h / calc(alpha * 0.2));
   }
   html.dark .comment-btn-wrapper {
-    --box-shadow-color: rgba(0, 0, 0, 0.36);
+    --box-shadow-color: oklch(from var(--vp-c-brand-1) calc(l / 2.5) c h / calc(alpha * 0.2));
+    --box-shadow-hover-color: oklch(from var(--vp-c-brand-1) calc(l / 5) c h / calc(alpha * 0.7));
   }
   .comment-btn-wrapper :is(.icon-wrapper, .icon-wrapper-text) {
     backdrop-filter: blur(3px);
+  }
+  .comment-btn-wrapper :is(.icon-wrapper, .icon-wrapper-text):not(:hover):not(:active) {
+    background-color: rgb(from var(--vp-c-brand-soft) r g b / calc(alpha * 0.6));
+    color: rgb(from var(--vp-c-brand-1) r g b / calc(alpha * 0.6));
   }
 }
 

--- a/packages/vitepress-plugin-image-preview/src/components/ImageViewer.vue
+++ b/packages/vitepress-plugin-image-preview/src/components/ImageViewer.vue
@@ -372,7 +372,12 @@ html.dark .vitepress-image-viewer__btn:active:not(.is-disabled) {
 }
 .vitepress-image-viewer__btn.is-disabled {
   cursor: not-allowed;
-  opacity: 0.4;
+  background-color: #00000016;
+  color: #fff6;
+  backdrop-filter: blur(1.5px);
+}
+html.dark .vitepress-image-viewer__btn.is-disabled {
+  background-color: #60626633;
 }
 
 .vitepress-image-viewer__close {
@@ -457,6 +462,7 @@ html.dark .vitepress-image-viewer__btn:active:not(.is-disabled) {
   opacity: 0.8;
   -webkit-text-stroke: 1.5px black;
   paint-order: stroke fill;
+  font-variant-numeric: tabular-nums;
 }
 
 .vitepress-image-viewer__canvas {

--- a/packages/vitepress-plugin-pagefind/build-mpa-vue.mjs
+++ b/packages/vitepress-plugin-pagefind/build-mpa-vue.mjs
@@ -1,0 +1,32 @@
+// @ts-check
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, relative, resolve } from 'node:path'
+import ts from 'typescript'
+
+const mpaVues = ['SearchMPA', 'SearchMPADefault']
+
+for (const mpaVue of mpaVues) {
+  const srcPath = resolve(import.meta.dirname, `./src/${mpaVue}.vue`)
+  const distPath = resolve(import.meta.dirname, `./dist/${mpaVue}.vue`)
+  let vueContent = await readFile(srcPath, 'utf-8')
+  vueContent = vueContent.replace(/<script client.*?>(.*?)<\/script>/gs, (_, tsSource) =>
+    `<script client>\n${compileTypeScript(tsSource)}</script>`)
+  vueContent = vueContent.replace(/import type .*\n/g, '')
+  vueContent = vueContent.replace(/@import '(.*)'/g, (_, path) =>
+    `@import '${relative(dirname(distPath), resolve(dirname(srcPath), path)).replaceAll('\\', '/')}'`)
+  writeFile(distPath, vueContent, 'utf-8')
+}
+
+/**
+ * @param {string} source
+ * @param {keyof typeof ts.ScriptTarget} target
+ */
+function compileTypeScript(source, target = 'ESNext') {
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget[target],
+      alwaysStrict: false,
+    },
+  }).outputText
+}

--- a/packages/vitepress-plugin-pagefind/package.json
+++ b/packages/vitepress-plugin-pagefind/package.json
@@ -34,7 +34,8 @@
   ],
   "scripts": {
     "dev": "npx tsup src/index.ts --dts --watch --format esm,cjs --sourcemap",
-    "build": "npx tsup src/index.ts --dts --format esm,cjs --silent --sourcemap"
+    "build": "npx tsup src/index.ts --dts --format esm,cjs --silent --sourcemap && npm run build:mpa-vue",
+    "build:mpa-vue": "node build-mpa-vue.mjs"
   },
   "peerDependencies": {
     "pagefind": "^1.1.0",

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 
-import { useData, useRoute, useRouter, withBase } from 'vitepress'
+import { inBrowser, useData, useRoute, useRouter, withBase } from 'vitepress'
 import { useLocalStorage, useMagicKeys } from '@vueuse/core'
 
 // @ts-expect-error
@@ -40,22 +40,16 @@ const showLoadingMask = computed(() => finalSearchConfig.value?.showLoadingMask 
 const formatShowDateFn = computed(() => typeof finalSearchConfig.value.showDate === 'function' ? finalSearchConfig.value.showDate : formatShowDate)
 
 // 搜索条数展示
-const headingText = computed(() => {
-  return finalSearchConfig.value?.heading
+const headingText = computed(() =>
+  finalSearchConfig.value?.heading
     ? finalSearchConfig.value.heading.replace(
       /\{\{searchResult\}\}/,
       `${searchResult.value.length}`
     )
-    : `Total: ${searchResult.value.length} search results.`
-})
+    : `Total: ${searchResult.value.length} search results.`)
 
 // 展示的快捷键
-const metaKey = ref('')
-onMounted(() => {
-  metaKey.value = /(Mac|iPhone|iPod|iPad)/i.test(navigator?.platform)
-    ? '⌘'
-    : 'Ctrl'
-})
+const metaKey = computed(() => inBrowser && /(Mac|iPhone|iPod|iPad)/i.test(navigator?.platform) ? '⌘' : 'Ctrl')
 
 // 控制搜索框的展示
 const searchModal = ref(false)
@@ -256,20 +250,20 @@ function handleSelect(target: any) {
 }
 
 // 语言切换，重载页面
-const langReload = computed(() => finalSearchConfig.value.langReload ?? true)
-watch(
-  () => lang.value,
-  () => {
-    // 不在开发环境生效
-    if (import.meta.env.DEV) {
-      return
-    }
-    // 重载页面
-    if (langReload.value) {
-      window.location.reload()
-    }
-  }
-)
+// const langReload = computed(() => finalSearchConfig.value.langReload ?? true)
+// watch(
+//   () => lang.value,
+//   () => {
+//     // 不在开发环境生效
+//     if (import.meta.env.DEV) {
+//       return
+//     }
+//     // 重载页面
+//     if (langReload.value) {
+//       window.location.reload()
+//     }
+//   }
+// )
 
 // 清空搜索关键词
 const searchInput = ref<HTMLInputElement>()

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -8,11 +8,11 @@ import { searchConfig as _searchConfig } from 'virtual:pagefind'
 import { Command } from './command-palette'
 import LogoPagefind from './LogoPagefind.vue'
 import type { SearchConfig, SearchItem } from './type'
-import { formatPagefindResult } from './search'
+import { extractFuzzyKeywordsFromExcerpts, formatPagefindResult } from './search'
 import { formatShowDate } from './utils'
 
 // 搜索结果
-const searchResult = ref<{ route: string; meta: Record<string, any> }[]>([])
+const searchResult = ref<Omit<SearchItem, 'result'>[]>([])
 // 是否正在搜索中
 const isSearching = ref(false)
 // 配置获取
@@ -101,10 +101,10 @@ function inlineSearch() {
     searchResult.value = []
     return
   }
-  searchResult.value = Array.from({ length: 20 }, () => ({
+  searchResult.value = Array.from({ length: 1 }, () => ({
     route: '#',
     meta: {
-      title: '只在构建后才生效',
+      title: ['只在构建后才生效'],
       description: '<mark>only support after build</mark>, only support after build'
     }
   }))
@@ -155,26 +155,28 @@ watch(
     try {
       await window?.__pagefind__
         ?.debouncedSearch?.(searchText, {}, searchDelayTime.value)
-        .then(async (pagefindSearchResult: any) => {
+        .then(async (pagefindSearchResult) => {
           if (pagefindSearchResult === null) {
             // 该次搜索被后续输入取消，保持 loading 状态
             return
           }
           // pagefind 搜索结果
           const pagefindResults = await Promise.all(
-            pagefindSearchResult.results.map((v: any) => v.data())
+            pagefindSearchResult.results.map(v => v.data())
           )
+          // 获取所有模糊匹配的关键词
+          const fuzzyKeywords = extractFuzzyKeywordsFromExcerpts(pagefindResults, searchText)
           // 格式化搜索结果
           const formattedResults = pagefindResults
             .map((r) => {
-              const results = formatPagefindResult(r, finalSearchConfig.value.pageResultCount || 1)
-              return results.map((result) => {
+              const results = formatPagefindResult(r, finalSearchConfig.value.pageResultCount || 1, fuzzyKeywords)
+              results.forEach((result) => {
                 // base 兼容
                 result.route = result.route.startsWith(site.value.base)
                   ? result.route
                   : withBase(result.route)
-                return result as SearchItem
               })
+              return results
             })
             .flat()
             // 过滤掉未发布的
@@ -195,13 +197,6 @@ watch(
     catch {
       isSearching.value = false
     }
-
-    nextTick(() => {
-      // hack 原组件实现
-      document.querySelectorAll('div[aria-disabled="true"]').forEach((v) => {
-        v.setAttribute('aria-disabled', 'false')
-      })
-    })
   }
 )
 // 避免按住搜索框内选中文本拖动出来到遮罩上导致对话框关闭的问题。
@@ -268,6 +263,7 @@ watch(
     // 重载 pagefind
     const pagefind = window?.__pagefind__
     if (langReload.value && pagefind) {
+      handleClearSearch()
       await pagefind.destroy()
       await pagefind.init()
     }
@@ -362,7 +358,13 @@ function handleToggleDetail() {
                 >
                   <div class="link">
                     <div class="title">
-                      <span class="headings"><i v-if="item.meta.title" class="prefix"># </i>{{ item.meta.title }}</span>
+                      <span class="headings">
+                        <i v-if="item.meta.title?.length" class="prefix"># </i>
+                        <template v-for="(title, i) in item.meta.title" :key="title">
+                          <span v-if="i" class="vpi-chevron-right local-search-icon" />
+                          <span class="text">{{ title }}</span>
+                        </template>
+                      </span>
                       <span v-if="showDateInfo && item.meta.date" class="date">
                         <!-- @vue-ignore -->
                         {{ formatShowDateFn(item.meta.date, lang) }}</span>

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -360,9 +360,9 @@ function handleToggleDetail() {
                     <div class="title">
                       <span class="headings">
                         <i v-if="item.meta.title?.length" class="prefix">#</i>
-                        <template v-for="(title, i) in item.meta.title" :key="title">
+                        <template v-for="(heading, i) in item.meta.title" :key="heading">
                           <i v-if="i" class="vpi-chevron-right local-search-icon" />
-                          <span class="heading" v-html="title" />
+                          <span class="heading" v-html="heading" />
                         </template>
                       </span>
                       <span v-if="showDateInfo && item.meta.date" class="date">

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -42,10 +42,16 @@ const formatShowDateFn = computed(() => typeof finalSearchConfig.value.showDate 
 const headingText = computed(() =>
   finalSearchConfig.value?.heading
     ? finalSearchConfig.value.heading.replace(
-      /\{\{searchResult\}\}/,
+      '{{searchResult}}',
       `${searchResult.value.length}`
     )
     : `Total: ${searchResult.value.length} search results.`)
+
+// 修复第一次执行搜索时不显示搜索条数字样，因为被滚动到界面外了
+const commandList = ref<InstanceType<typeof Command.List>>()
+watch(searchResult, async () => {
+  commandList.value?.requestScrollToTop()
+})
 
 // 展示的快捷键
 const metaKey = computed(() => inBrowser && /(Mac|iPhone|iPod|iPad)/i.test(navigator?.platform) ? '⌘' : 'Ctrl')
@@ -95,7 +101,7 @@ function inlineSearch() {
     searchResult.value = []
     return
   }
-  searchResult.value = Array.from({ length: 1 }, () => ({
+  searchResult.value = Array.from({ length: 20 }, () => ({
     route: '#',
     meta: {
       title: '只在构建后才生效',
@@ -334,7 +340,7 @@ function handleToggleDetail() {
         </template>
         <template #body>
           <div class="search-dialog" :class="{ 'detail-list': showDetail }">
-            <Command.List>
+            <Command.List ref="commandList">
               <template v-if="!searchResult.length">
                 <div v-if="isSearching" class="search-loading">
                   <span class="search-loading-spinner" />

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -1,14 +1,13 @@
 <script lang="ts" setup>
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 
 import { inBrowser, useData, useRoute, useRouter, withBase } from 'vitepress'
 import { useLocalStorage, useMagicKeys } from '@vueuse/core'
 
-// @ts-expect-error
 import { searchConfig as _searchConfig } from 'virtual:pagefind'
 import { Command } from './command-palette'
 import LogoPagefind from './LogoPagefind.vue'
-import type { SearchConfig } from './type'
+import type { SearchConfig, SearchItem } from './type'
 import { formatPagefindResult } from './search'
 import { formatShowDate } from './utils'
 
@@ -105,7 +104,7 @@ function inlineSearch() {
   }))
 }
 
-const chineseRegex = /[\u4E00-\u9FA5]/g
+const chineseRegex = /\p{Ideo}/gu
 const segmenterCh = Intl?.Segmenter && new Intl.Segmenter('zh-CN', { granularity: 'word' })
 function chineseSearchOptimize(input: string) {
   if (segmenterCh) {
@@ -135,7 +134,6 @@ watch(
     isSearching.value = true
 
     // dev-server兜底
-    // @ts-expect-error
     if (!window?.__pagefind__?.search) {
       inlineSearch()
       isSearching.value = false
@@ -149,7 +147,6 @@ watch(
         // 判断有中文，默认启用优化
         : (chineseRegex.test(searchWords.value) ? chineseSearchOptimize(searchWords.value) : searchWords.value)
     try {
-      // @ts-expect-error
       await window?.__pagefind__
         ?.debouncedSearch?.(searchText, {}, searchDelayTime.value)
         .then(async (pagefindSearchResult: any) => {
@@ -170,7 +167,7 @@ watch(
                 result.route = result.route.startsWith(site.value.base)
                   ? result.route
                   : withBase(result.route)
-                return result
+                return result as SearchItem
               })
             })
             .flat()
@@ -249,24 +246,26 @@ function handleSelect(target: any) {
   }
 }
 
-// 语言切换，重载页面
-// const langReload = computed(() => finalSearchConfig.value.langReload ?? true)
-// watch(
-//   () => lang.value,
-//   () => {
-//     // 不在开发环境生效
-//     if (import.meta.env.DEV) {
-//       return
-//     }
-//     // 重载页面
-//     if (langReload.value) {
-//       window.location.reload()
-//     }
-//   }
-// )
+// 语言切换，重载 pagefind
+const langReload = computed(() => finalSearchConfig.value.langReload ?? true)
+watch(
+  () => lang.value,
+  async () => {
+    // 不在开发环境生效
+    if (import.meta.env.DEV) {
+      return
+    }
+    // 重载 pagefind
+    const pagefind = window?.__pagefind__
+    if (langReload.value && pagefind) {
+      await pagefind.destroy()
+      await pagefind.init()
+    }
+  }
+)
 
 // 清空搜索关键词
-const searchInput = ref<HTMLInputElement>()
+const searchInput = ref<InstanceType<typeof Command.Input>>()
 function handleClearSearch() {
   searchWords.value = ''
   searchResult.value = []
@@ -274,8 +273,7 @@ function handleClearSearch() {
   nextTick(() => {
     if (!searchInput.value)
       return
-    // @ts-expect-error
-    searchInput.value.$el.value = ''
+    (searchInput.value.$el as HTMLInputElement).value = ''
   })
 }
 

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -53,9 +53,6 @@ watch(searchResult, async () => {
   commandList.value?.requestScrollToTop()
 })
 
-// 展示的快捷键
-const metaKey = computed(() => inBrowser && /(Mac|iPhone|iPod|iPad)/i.test(navigator?.platform) ? '⌘' : 'Ctrl')
-
 // 控制搜索框的展示
 const searchModal = ref(false)
 function showSearchModal() {
@@ -304,7 +301,7 @@ function handleToggleDetail() {
       <span class="search-tip">{{
         finalSearchConfig?.btnPlaceholder || 'Search'
       }}</span>
-      <span class="metaKey"> {{ metaKey }} K </span>
+      <span class="metaKey" />
     </button>
     <ClientOnly>
       <Command.Dialog :visible="searchModal" theme="algolia" :footer-class="{ 'no-search-result': !searchResult.length }">
@@ -623,6 +620,14 @@ label.search-icon {
   color: var(--vp-c-text-1);
   font-size: 14px;
   font-weight: 500;
+}
+
+.metaKey::before {
+  content: "Ctrl K"
+}
+
+html.mac .metaKey::before {
+  content: "⌘ K"
 }
 
 @keyframes search-mask-spin {

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -228,6 +228,8 @@ watch(
       const mask = document.querySelector('div[command-dialog-mask]')
       mask?.removeEventListener('click', handleClickMask)
       mask?.removeEventListener('mousedown', handleMouseDownMask)
+      if (finalSearchConfig.value.clearWhenClosed)
+        handleClearSearch()
     }
   }
 )
@@ -292,7 +294,7 @@ function handleToggleDetail() {
 
 <template>
   <div class="blog-search" data-pagefind-ignore="all">
-    <button class="nav-search-btn-wait" @click="searchModal = true">
+    <button class="nav-search-btn-wait" @click="showSearchModal">
       <span>
         <svg viewBox="0 0 20 20">
           <path
@@ -311,7 +313,7 @@ function handleToggleDetail() {
         <template #header>
           <div class="search-bar">
             <div class="search-actions before">
-              <button class="back-button" :title="finalSearchConfig?.closeSearch || 'Close search'" @click="searchModal = false">
+              <button class="back-button" :title="finalSearchConfig?.closeSearch || 'Close search'" @click="hideSearchModal">
                 <span class="vpi-arrow-left local-search-icon" />
               </button>
             </div>
@@ -319,7 +321,7 @@ function handleToggleDetail() {
               <span aria-hidden="true" class="vpi-search search-icon local-search-icon" />
             </label>
             <Command.Input
-              id="search-input" ref="searchInput" v-model:value="searchWords"
+              id="search-input" ref="searchInput" v-model="searchWords"
               :placeholder="finalSearchConfig?.placeholder || 'Search Docs'"
             />
             <div class="search-actions">

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -228,7 +228,7 @@ watch(
       const mask = document.querySelector('div[command-dialog-mask]')
       mask?.removeEventListener('click', handleClickMask)
       mask?.removeEventListener('mousedown', handleMouseDownMask)
-      if (finalSearchConfig.value.clearWhenClosed)
+      if (finalSearchConfig.value.clearWhenClosed === 'always')
         handleClearSearch()
     }
   }
@@ -249,6 +249,8 @@ const router = useRouter()
 const route = useRoute()
 function handleSelect(target: any) {
   hideSearchModal()
+  if (finalSearchConfig.value.clearWhenClosed === 'visit')
+    handleClearSearch()
   if (route.path !== target.value) {
     router.go(target.value)
   }

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -242,7 +242,7 @@ const showSearchResult = computed(() => {
 // 选择搜索结果跳转
 const router = useRouter()
 const route = useRoute()
-function handleSelect(target: any) {
+function handleSelect(target: { key: string; value: string }) {
   hideSearchModal()
   if (finalSearchConfig.value.clearWhenClosed === 'visit')
     handleClearSearch()

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -359,10 +359,10 @@ function handleToggleDetail() {
                   <div class="link">
                     <div class="title">
                       <span class="headings">
-                        <i v-if="item.meta.title?.length" class="prefix"># </i>
+                        <i v-if="item.meta.title?.length" class="prefix">#</i>
                         <template v-for="(title, i) in item.meta.title" :key="title">
-                          <span v-if="i" class="vpi-chevron-right local-search-icon" />
-                          <span class="text">{{ title }}</span>
+                          <i v-if="i" class="vpi-chevron-right local-search-icon" />
+                          <span class="heading" v-html="title" />
                         </template>
                       </span>
                       <span v-if="showDateInfo && item.meta.date" class="date">

--- a/packages/vitepress-plugin-pagefind/src/Search.vue
+++ b/packages/vitepress-plugin-pagefind/src/Search.vue
@@ -309,11 +309,11 @@ function handleToggleDetail() {
       <span class="metaKey"> {{ metaKey }} K </span>
     </button>
     <ClientOnly>
-      <Command.Dialog :visible="searchModal" theme="algolia">
+      <Command.Dialog :visible="searchModal" theme="algolia" :footer-class="{ 'no-search-result': !searchResult.length }">
         <template #header>
           <div class="search-bar">
             <div class="search-actions before">
-              <button class="back-button" title="Close search" @click="searchModal = false">
+              <button class="back-button" :title="finalSearchConfig?.closeSearch || 'Close search'" @click="searchModal = false">
                 <span class="vpi-arrow-left local-search-icon" />
               </button>
             </div>
@@ -381,7 +381,7 @@ function handleToggleDetail() {
             </div>
           </div>
         </template>
-        <template v-if="searchResult.length" #footer>
+        <template #footer>
           <div class="command-palette-logo">
             <a href="https://github.com/cloudcannon/pagefind" target="_blank" rel="noopener noreferrer">
               <span class="command-palette-Label">{{ finalSearchConfig?.searchBy || 'Search by' }}</span>
@@ -637,6 +637,10 @@ label.search-icon {
 
   label.search-icon {
     display: none;
+  }
+
+  .search-bar .search-actions {
+    padding-right: 4px;
   }
 }
 </style>

--- a/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
@@ -519,7 +519,7 @@ input.addEventListener('input', handleSearch)
         </svg>
       </span>
       <span class="search-tip">{{ finalSearchConfig?.btnPlaceholder || 'Search' }}</span>
-      <span class="metaKey"> Ctrl K </span>
+      <span class="metaKey" />
     </div>
 
     <div id="search-modal" class="algolia">
@@ -795,6 +795,14 @@ label.search-icon {
   .search-bar .search-actions {
     padding-right: 4px;
   }
+}
+
+.metaKey::before {
+  content: "Ctrl K"
+}
+
+html.mac .metaKey::before {
+  content: "⌘ K"
 }
 </style>
 

--- a/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
@@ -386,7 +386,7 @@ const debouncedRealSearch = debounce(async (val: string) => {
 
     const search = await window.__pagefind__.debouncedSearch(searchText)
     if (search && search.results) {
-      const pagefindResults = await Promise.all(search.results.map(r => r.data() as unknown as Promise<PagefindResult>))
+      const pagefindResults = await Promise.all(search.results.map(r => r.data()))
       const formatted = pagefindResults
         .map(r => formatPagefindResult(r, currentSearchConfig.pageResultCount || 1))
         .flat()

--- a/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
@@ -231,7 +231,7 @@ const list = document.getElementById('search-list')!
 const clearBtn = document.getElementById('search-clear-btn') as HTMLButtonElement
 const toggleBtn = document.getElementById('search-toggle-detail') as HTMLButtonElement
 const backBtn = document.getElementById('search-back-btn') as HTMLButtonElement
-const mask = modal.querySelector('[command-dialog-mask]')!
+const mask = modal.querySelector('[command-dialog-mask]') as HTMLDivElement
 const footer = modal.querySelector('[command-dialog-footer]')!
 
 let showDetail = localStorage.getItem('pagefind-search-showDetail') === 'true'
@@ -242,13 +242,13 @@ if (showDetail)
   toggleBtn.classList.add('active')
 
 function openModal() {
-  modal.style.display = 'block'
+  mask.hidden = false
   input.focus()
   loadPagefind()
 }
 
 function closeModal() {
-  modal.style.display = 'none'
+  mask.hidden = true
   if (currentSearchConfig.clearWhenClosed === 'always')
     handleClearSearch()
 }
@@ -274,7 +274,7 @@ document.addEventListener('keydown', (e) => {
     e.preventDefault()
     openModal()
   }
-  if (e.key === 'Escape' && modal.style.display === 'block') {
+  if (e.key === 'Escape' && !mask.hidden) {
     closeModal()
   }
 })
@@ -508,7 +508,7 @@ input.addEventListener('input', handleSearch)
 </script>
 
 <template>
-  <div class="blog-search" data-pagefind-ignore="all">
+  <div class="blog-search mpa" data-pagefind-ignore="all">
     <div id="search-trigger" class="nav-search-btn-wait">
       <span>
         <svg width="14" height="14" viewBox="0 0 20 20">
@@ -522,8 +522,8 @@ input.addEventListener('input', handleSearch)
       <span class="metaKey"> Ctrl K </span>
     </div>
 
-    <div id="search-modal" class="algolia" style="display: none;">
-      <div command-dialog-mask>
+    <div id="search-modal" class="algolia">
+      <div command-dialog-mask hidden>
         <div command-dialog-wrapper>
           <div command-dialog-header>
             <div class="search-bar">

--- a/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
@@ -226,6 +226,8 @@ function debounce<T extends (...args: any[]) => any>(func: T, wait: number) {
 // Main logic
 const trigger = document.getElementById('search-trigger')!
 const modal = document.getElementById('search-modal')!
+if (modal.parentElement !== document.body)
+  document.body.appendChild(modal)
 const input = document.getElementById('search-input') as HTMLInputElement
 const list = document.getElementById('search-list')!
 const clearBtn = document.getElementById('search-clear-btn') as HTMLButtonElement

--- a/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
@@ -461,7 +461,7 @@ input.addEventListener('input', handleSearch)
           <div command-dialog-header>
             <div class="search-bar">
               <div class="search-actions before">
-                <button id="search-back-btn" class="back-button" title="Close search">
+                <button id="search-back-btn" class="back-button" :title="finalSearchConfig?.closeSearch || 'Close search'">
                   <span class="vpi-arrow-left local-search-icon" />
                 </button>
               </div>
@@ -723,6 +723,10 @@ label.search-icon {
 
   label.search-icon {
     display: none;
+  }
+
+  .search-bar .search-actions {
+    padding-right: 4px;
   }
 }
 </style>

--- a/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
@@ -232,6 +232,7 @@ const clearBtn = document.getElementById('search-clear-btn') as HTMLButtonElemen
 const toggleBtn = document.getElementById('search-toggle-detail') as HTMLButtonElement
 const backBtn = document.getElementById('search-back-btn') as HTMLButtonElement
 const mask = modal.querySelector('[command-dialog-mask]')!
+const footer = modal.querySelector('[command-dialog-footer]')!
 
 let showDetail = localStorage.getItem('pagefind-search-showDetail') === 'true'
 const dialog = modal.querySelector('.search-dialog')!
@@ -250,6 +251,10 @@ function closeModal() {
   modal.style.display = 'none'
   if (currentSearchConfig.clearWhenClosed === 'always')
     handleClearSearch()
+}
+
+function setFooterNoSearchResult(hasResult: boolean) {
+  footer?.classList.toggle('no-search-result', !hasResult)
 }
 
 trigger.addEventListener('click', openModal)
@@ -293,6 +298,7 @@ let selectedIndex = -1
 
 function renderLoading() {
   list.innerHTML = `<div command-loading><span command-loading-spinner></span>${currentSearchConfig.loadingText || 'Searching...'}</div>`
+  setFooterNoSearchResult(true)
   selectedIndex = -1
 }
 
@@ -320,6 +326,7 @@ function renderList(results: SearchItem[], { showEmptyText = false } = {}) {
       ? `<div command-empty>${currentSearchConfig.emptyText || 'No results found.'}</div>`
       : ''
     selectedIndex = -1
+    setFooterNoSearchResult(showEmptyText)
     return
   }
 
@@ -353,6 +360,7 @@ function renderList(results: SearchItem[], { showEmptyText = false } = {}) {
       </div>
     `
   list.innerHTML = html
+  setFooterNoSearchResult(true)
 
   // Add click events
   const items = list.querySelectorAll<HTMLElement>('[command-item]')
@@ -549,7 +557,7 @@ input.addEventListener('input', handleSearch)
               <div id="search-list" command-list />
             </div>
           </div>
-          <div command-dialog-footer>
+          <div command-dialog-footer class="no-search-result">
             <div class="command-palette-logo">
               <a href="https://github.com/cloudcannon/pagefind" target="_blank" rel="noopener noreferrer">
                 <span class="command-palette-Label">{{ finalSearchConfig?.searchBy || 'Search by' }}</span>

--- a/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
@@ -191,6 +191,8 @@ function openModal() {
 
 function closeModal() {
   modal.style.display = 'none'
+  if (currentSearchConfig.clearWhenClosed === 'always')
+    handleClearSearch()
 }
 
 trigger.addEventListener('click', openModal)
@@ -222,12 +224,13 @@ toggleBtn.addEventListener('click', () => {
   toggleBtn.classList.toggle('active', showDetail)
 })
 
-clearBtn.addEventListener('click', () => {
+clearBtn.addEventListener('click', handleClearSearch)
+function handleClearSearch() {
   input.value = ''
   renderList([])
   clearBtn.disabled = true
   input.focus()
-})
+}
 
 let selectedIndex = -1
 

--- a/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useData } from 'vitepress'
-
-// @ts-expect-error
 import { searchConfig } from 'virtual:pagefind'
+import type { PagefindResult, SearchConfig, SearchItem } from './type'
+import type { PagefindSearchAnchor, PagefindSubResult } from './types/pagefind'
 
 const { site, lang, localeIndex } = useData()
 const finalSearchConfig = computed(() => {
@@ -20,18 +20,18 @@ const stringifySearchConfig = computed(() => {
 
 <script client>
 const dataEl = document.getElementById('search-data')
-const currentLang = dataEl?.dataset.lang || 'en-us'
+const currentLang = dataEl?.dataset.lang || 'en-US'
 const base = dataEl?.dataset.base || '/'
 const currentLocaleIndex = dataEl?.dataset.locale || 'root'
 
-const searchConfig = JSON.parse(decodeURIComponent(dataEl?.dataset.searchConfig || '{}'))
+const _searchConfig: SearchConfig = JSON.parse(decodeURIComponent(dataEl?.dataset.searchConfig || '{}'))
 const currentSearchConfig = {
-  ...searchConfig,
-  ...(searchConfig?.locales?.[currentLocaleIndex] || {})
+  ..._searchConfig,
+  ...(_searchConfig?.locales?.[currentLocaleIndex] || {})
 }
 
 // Helper functions
-function decodeBase64AndDeserialize(base64String) {
+function decodeBase64AndDeserialize(base64String: string) {
   if (!base64String)
     return {}
   try {
@@ -42,60 +42,44 @@ function decodeBase64AndDeserialize(base64String) {
   }
 }
 
-function formatDate(d, fmt = 'yyyy-MM-dd hh:mm:ss') {
-  if (!(d instanceof Date))
-    d = new Date(d)
-  const o = {
-    'M+': d.getMonth() + 1,
-    'd+': d.getDate(),
-    'h+': d.getHours(),
-    'm+': d.getMinutes(),
-    's+': d.getSeconds(),
-    'q+': Math.floor((d.getMonth() + 3) / 3),
-    'S': d.getMilliseconds()
+function formatDate(date: Date | string, lang: string) {
+  if (!(date instanceof Date)) {
+    date = new Date(date)
   }
-  if (/(y+)/.test(fmt)) {
-    fmt = fmt.replace(RegExp.$1, `${d.getFullYear()}`.substr(4 - RegExp.$1.length))
-  }
-  for (const k in o) {
-    if (new RegExp(`(${k})`).test(fmt)) {
-      fmt = fmt.replace(RegExp.$1, RegExp.$1.length === 1 ? o[k] : `00${o[k]}`.substr(`${o[k]}`.length))
-    }
-  }
-  return fmt
+
+  return new Intl.DateTimeFormat(lang, { year: 'numeric', month: '2-digit', day: '2-digit' }).format(date)
 }
 
-function formatShowDate(date, lang) {
-  if (typeof currentSearchConfig.showDate === 'function') {
-    return currentSearchConfig.showDate(date, lang)
-  }
+function formatShowDate(date: Date | string, lang: string) {
   const source = +new Date(date)
   const now = +new Date()
-  const diff = now - source
+  const diff = source - now
+
   const oneSeconds = 1000
   const oneMinute = oneSeconds * 60
   const oneHour = oneMinute * 60
   const oneDay = oneHour * 24
   const oneWeek = oneDay * 7
-  const langMap = {
-    'zh-cn': { justNow: '刚刚', secondsAgo: '秒前', minutesAgo: '分钟前', hoursAgo: '小时前', daysAgo: '天前', weeksAgo: '周前' },
-    'en-us': { justNow: ' just now', secondsAgo: ' seconds ago', minutesAgo: ' minutes ago', hoursAgo: ' hours ago', daysAgo: ' days ago', weeksAgo: ' weeks ago' }
+
+  const formatter = new Intl.RelativeTimeFormat(lang, { style: 'long', numeric: 'auto' })
+
+  if (Math.abs(diff) < oneMinute) {
+    return formatter.format(Math.trunc(diff / oneSeconds), 'second')
   }
-  const mapValue = langMap[lang.toLowerCase()] || langMap['en-us']
-  if (diff < 10)
-    return mapValue.justNow
-  if (diff < oneMinute)
-    return `${Math.floor(diff / oneSeconds)}${mapValue.secondsAgo}`
-  if (diff < oneHour)
-    return `${Math.floor(diff / oneMinute)}${mapValue.minutesAgo}`
-  if (diff < oneDay)
-    return `${Math.floor(diff / oneHour)}${mapValue.hoursAgo}`
-  if (diff < oneWeek)
-    return `${Math.floor(diff / oneDay)}${mapValue.daysAgo}`
-  return formatDate(new Date(date), 'yyyy-MM-dd')
+  if (Math.abs(diff) < oneHour) {
+    return formatter.format(Math.trunc(diff / oneMinute), 'minute')
+  }
+  if (Math.abs(diff) < oneDay) {
+    return formatter.format(Math.trunc(diff / oneHour), 'hour')
+  }
+  if (Math.abs(diff) < oneWeek) {
+    return formatter.format(Math.trunc(diff / oneDay), 'day')
+  }
+
+  return formatDate(new Date(date), lang)
 }
 
-function formatPagefindResult(result, count = 1) {
+function formatPagefindResult(result: PagefindResult, count = 1) {
   const { sub_results: subResults, anchors, weighted_locations: weightedLocations } = result
   weightedLocations.sort((a, b) => {
     if (b.weight === a.weight)
@@ -112,7 +96,7 @@ function formatPagefindResult(result, count = 1) {
       const max = locations.length === 1 ? Number.POSITIVE_INFINITY : locations[locations.length - 1]
       return min <= location && location <= max
     })
-    const sub = filterData.reduce((prev, curr) => {
+    const sub = filterData.reduce<PagefindSubResult | null>((prev, curr) => {
       if (!prev)
         return curr
       return prev.locations.length > curr.locations.length ? prev : curr
@@ -140,24 +124,26 @@ function formatPagefindResult(result, count = 1) {
     })
 }
 
-function parseSubResult(sub, anchors, result) {
+function parseSubResult(sub: PagefindSubResult, anchors: PagefindSearchAnchor[], result: PagefindResult): SearchItem {
   const route = sub?.url || result?.url
   const description = sub?.excerpt || result?.excerpt
   const locationsAnchors = anchors?.filter((a) => {
     if (!sub)
       return false
-    try { return a.location <= sub.anchor.location && a.element <= sub.anchor.element }
+    try {
+      return a.location <= sub.anchor!.location && a.element <= sub.anchor!.element
+    }
     catch { return false }
   }) || []
   locationsAnchors.reverse()
-  const filteredAnchors = locationsAnchors.reduce((prev, curr) => {
+  const filteredAnchors = locationsAnchors.reduce<PagefindSearchAnchor[]>((prev, curr) => {
     const isHave = prev.some(p => p.element === curr.element)
     if (isHave)
       return prev
     prev.unshift(curr)
     return prev
   }, [])
-  const title = filteredAnchors.length ? filteredAnchors.map(t => t.text.trim()).filter(v => !!v).join(' > ') : result.meta.title
+  const title = filteredAnchors.length ? filteredAnchors.map(t => t.text!.trim()).filter(v => !!v).join(' > ') : result.meta.title
   const { base64, date, ...otherMeta } = result.meta
   return {
     route,
@@ -172,26 +158,26 @@ function parseSubResult(sub, anchors, result) {
   }
 }
 
-function debounce(func, wait) {
-  let timeout
-  return function (...args) {
+function debounce<T extends (...args: any[]) => any>(func: T, wait: number) {
+  let timeout: NodeJS.Timeout
+  return function (this: any, ...args: any[]) {
     clearTimeout(timeout)
     timeout = setTimeout(() => func.apply(this, args), wait)
-  }
+  } as T
 }
 
 // Main logic
-const trigger = document.getElementById('search-trigger')
-const modal = document.getElementById('search-modal')
-const input = document.getElementById('search-input')
-const list = document.getElementById('search-list')
-const clearBtn = document.getElementById('search-clear-btn')
-const toggleBtn = document.getElementById('search-toggle-detail')
-const backBtn = document.getElementById('search-back-btn')
-const mask = modal.querySelector('[command-dialog-mask]')
+const trigger = document.getElementById('search-trigger')!
+const modal = document.getElementById('search-modal')!
+const input = document.getElementById('search-input') as HTMLInputElement
+const list = document.getElementById('search-list')!
+const clearBtn = document.getElementById('search-clear-btn') as HTMLButtonElement
+const toggleBtn = document.getElementById('search-toggle-detail') as HTMLButtonElement
+const backBtn = document.getElementById('search-back-btn') as HTMLButtonElement
+const mask = modal.querySelector('[command-dialog-mask]')!
 
 let showDetail = localStorage.getItem('pagefind-search-showDetail') === 'true'
-const dialog = modal.querySelector('.search-dialog')
+const dialog = modal.querySelector('.search-dialog')!
 if (showDetail)
   dialog.classList.add('detail-list')
 if (showDetail)
@@ -210,7 +196,9 @@ function closeModal() {
 trigger.addEventListener('click', openModal)
 // 避免按住搜索框内选中文本拖动出来到遮罩上导致对话框关闭的问题。
 let lastMouseDownTarget: EventTarget | null = null
-mask.addEventListener('mousedown', (e) => { lastMouseDownTarget = e.target })
+mask.addEventListener('mousedown', (e) => {
+  lastMouseDownTarget = e.target
+})
 mask.addEventListener('click', (e) => {
   if (e.target === mask && lastMouseDownTarget === mask)
     closeModal()
@@ -229,7 +217,7 @@ document.addEventListener('keydown', (e) => {
 
 toggleBtn.addEventListener('click', () => {
   showDetail = !showDetail
-  localStorage.setItem('pagefind-search-showDetail', showDetail)
+  localStorage.setItem('pagefind-search-showDetail', String(showDetail))
   dialog.classList.toggle('detail-list', showDetail)
   toggleBtn.classList.toggle('active', showDetail)
 })
@@ -265,7 +253,7 @@ function hideResultOverlay() {
     overlay.remove()
 }
 
-function renderList(results, { showEmptyText = false } = {}) {
+function renderList(results: SearchItem[], { showEmptyText = false } = {}) {
   if (!results.length) {
     // 未输入关键词：空白；有关键词但无结果：展示 emptyText
     list.innerHTML = showEmptyText
@@ -276,7 +264,7 @@ function renderList(results, { showEmptyText = false } = {}) {
   }
 
   const heading = currentSearchConfig.heading
-    ? currentSearchConfig.heading.replace(/\{\{searchResult\}\}/, results.length)
+    ? currentSearchConfig.heading.replace(/\{\{searchResult\}\}/, String(results.length))
     : `Total: ${results.length} search results.`
   const html = `
       <div command-group>
@@ -297,10 +285,10 @@ function renderList(results, { showEmptyText = false } = {}) {
   list.innerHTML = html
 
   // Add click events
-  const items = list.querySelectorAll('[command-item]')
+  const items = list.querySelectorAll<HTMLElement>('[command-item]')
   items.forEach((item) => {
     item.addEventListener('click', () => {
-      const index = parseInt(item.dataset.index)
+      const index = parseInt(item.dataset.index!)
       const result = results[index]
       if (result) {
         window.location.href = result.route.startsWith(base) ? result.route : base + result.route.replace(/^\//, '')
@@ -309,14 +297,14 @@ function renderList(results, { showEmptyText = false } = {}) {
     })
     // Hover effect handling
     item.addEventListener('mouseenter', () => {
-      updateSelection(parseInt(item.dataset.index))
+      updateSelection(parseInt(item.dataset.index!))
     })
   })
   selectedIndex = -1
 }
 
-function updateSelection(index) {
-  const items = list.querySelectorAll('[command-item]')
+function updateSelection(index: number) {
+  const items = list.querySelectorAll<HTMLElement>('[command-item]')
   if (index >= items.length)
     index = items.length - 1
   if (index < 0)
@@ -334,7 +322,7 @@ function updateSelection(index) {
 
 // Keyboard navigation
 input.addEventListener('keydown', (e) => {
-  const items = list.querySelectorAll('[command-item]')
+  const items = list.querySelectorAll<HTMLElement>('[command-item]')
   if (items.length === 0)
     return
 
@@ -370,9 +358,9 @@ async function loadPagefind() {
   }
 }
 
-const chineseRegex = /[\u4E00-\u9FA5]/g
+const chineseRegex = /\p{Ideo}/gu
 const segmenterCh = Intl?.Segmenter && new Intl.Segmenter('zh-CN', { granularity: 'word' })
-function chineseSearchOptimize(input) {
+function chineseSearchOptimize(input: string) {
   if (segmenterCh) {
     const splitWords = Array.from(segmenterCh.segment(input))
     return splitWords.map(v => v.segment).join(' ')
@@ -383,7 +371,7 @@ function chineseSearchOptimize(input) {
     .trim()
 }
 
-const debouncedRealSearch = debounce(async (val) => {
+const debouncedRealSearch = debounce(async (val: string) => {
   if (!window.__pagefind__) {
     await loadPagefind()
   }
@@ -395,7 +383,7 @@ const debouncedRealSearch = debounce(async (val) => {
 
     const search = await window.__pagefind__.debouncedSearch(searchText)
     if (search && search.results) {
-      const pagefindResults = await Promise.all(search.results.map(r => r.data()))
+      const pagefindResults = await Promise.all(search.results.map(r => r.data() as unknown as Promise<PagefindResult>))
       const formatted = pagefindResults
         .map(r => formatPagefindResult(r, currentSearchConfig.pageResultCount || 1))
         .flat()
@@ -418,8 +406,8 @@ const debouncedRealSearch = debounce(async (val) => {
   hideResultOverlay()
 }, currentSearchConfig.delay || 300)
 
-function handleSearch(e) {
-  const val = e.target.value
+function handleSearch(e: InputEvent) {
+  const val = (e.target as HTMLInputElement).value
   clearBtn.disabled = !val
   if (!val) {
     renderList([])
@@ -590,7 +578,7 @@ input.addEventListener('input', handleSearch)
       </div>
     </div>
   </div>
-  <div id="search-data" :data-search-config="stringifySearchConfig" :data-lang="lang" :data-base="site.base" :data-locale="localeIndex" style="display: none;" />
+  <div id="search-data" :data-search-config="stringifySearchConfig" :data-lang="lang" :data-base="(site as unknown as typeof site.value).base" :data-locale="localeIndex" style="display: none;" />
 </template>
 
 <style lang="css" scoped>

--- a/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
@@ -3,7 +3,6 @@ import { computed } from 'vue'
 import { useData } from 'vitepress'
 import { searchConfig } from 'virtual:pagefind'
 import type { Anchor, PagefindResult, SearchConfig, SearchItem, SubResult } from './type'
-import type { PagefindSearchAnchor, PagefindSubResult } from './types/pagefind'
 
 const { site, lang, localeIndex } = useData()
 const finalSearchConfig = computed(() => {
@@ -18,7 +17,7 @@ const stringifySearchConfig = computed(() => {
 })
 </script>
 
-<script client>
+<script client lang="ts">
 const dataEl = document.getElementById('search-data')
 const currentLang = dataEl?.dataset.lang || 'en-US'
 const base = dataEl?.dataset.base || '/'
@@ -81,20 +80,15 @@ function formatShowDate(date: Date | string | number, lang: string) {
 
 function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKeywords: FuzzyKeywords) {
   const { sub_results: subResults, anchors, weighted_locations: weightedLocations } = result
-  // TODO：pick策略优化
-  // 按照权重排序，从大到小
   weightedLocations.sort((a, b) => {
-    // 权重相等按照 location 顺序排序
     if (b.weight === a.weight) {
       return a.location - b.location
     }
     return b.weight - a.weight
   })
 
-  // pick 集合中权重最大的结果
   const subs: SubResult[] = []
   for (const { location } of weightedLocations) {
-    // 从结果集合中过滤出符合权重的结果
     const filterData = subResults.filter((sub) => {
       const { locations } = sub
       const [min] = locations || []
@@ -105,7 +99,6 @@ function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKeywords: 
       return min <= location && location <= max
     })
 
-    // 保留 locations 数量最多的
     const sub = filterData.reduce((prev, curr) => {
       if (!prev) {
         return curr
@@ -124,7 +117,6 @@ function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKeywords: 
     }
   }
 
-  // 按文章中顺序，排序
   subs.sort((a, b) => {
     const [minA] = a.locations || []
     const [minB] = b.locations || []
@@ -149,13 +141,10 @@ function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResul
   const route = sub?.url || result?.url
   const description = sub?.excerpt || result?.excerpt
 
-  // 构造标题
-  // 过滤出合适的标题列表
   const locationsAnchors = anchors?.filter((a) => {
     if (!sub)
       return false
     try {
-      // 直接比较
       return a.location <= sub.anchor.location && a.element <= sub.anchor.element
     }
     catch {
@@ -172,7 +161,6 @@ function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResul
     prev.unshift(curr)
     return prev
   }, [] as Anchor[])
-  // 构造完整的 title 层级 信息
   const title = filteredAnchors.length
     ? filteredAnchors.map(t => markTextWithKeywords(t.text.trim(), fuzzyKeywords)).filter(Boolean)
     : [markTextWithKeywords(result.meta.title, fuzzyKeywords)]
@@ -353,7 +341,7 @@ function renderList(results: SearchItem[], { showEmptyText = false } = {}) {
                       ${item.meta.title.map((heading, i) => `
                         ${i ? '<i class="vpi-chevron-right local-search-icon"></i>' : ''}
                         <span class="heading">${heading}</span>
-                      `)}
+                      `).join('')}
                     `}
                 </span>
                 ${item.meta.date ? `<span class="date">${formatShowDate(item.meta.date, currentLang)}</span>` : ''}

--- a/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPA.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { useData } from 'vitepress'
 import { searchConfig } from 'virtual:pagefind'
-import type { PagefindResult, SearchConfig, SearchItem } from './type'
+import type { Anchor, PagefindResult, SearchConfig, SearchItem, SubResult } from './type'
 import type { PagefindSearchAnchor, PagefindSubResult } from './types/pagefind'
 
 const { site, lang, localeIndex } = useData()
@@ -50,7 +50,7 @@ function formatDate(date: Date | string, lang: string) {
   return new Intl.DateTimeFormat(lang, { year: 'numeric', month: '2-digit', day: '2-digit' }).format(date)
 }
 
-function formatShowDate(date: Date | string, lang: string) {
+function formatShowDate(date: Date | string | number, lang: string) {
   const source = +new Date(date)
   const now = +new Date()
   const diff = source - now
@@ -79,83 +79,152 @@ function formatShowDate(date: Date | string, lang: string) {
   return formatDate(new Date(date), lang)
 }
 
-function formatPagefindResult(result: PagefindResult, count = 1) {
+function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKeywords: FuzzyKeywords) {
   const { sub_results: subResults, anchors, weighted_locations: weightedLocations } = result
+  // TODO：pick策略优化
+  // 按照权重排序，从大到小
   weightedLocations.sort((a, b) => {
-    if (b.weight === a.weight)
+    // 权重相等按照 location 顺序排序
+    if (b.weight === a.weight) {
       return a.location - b.location
+    }
     return b.weight - a.weight
   })
-  const subs = []
+
+  // pick 集合中权重最大的结果
+  const subs: SubResult[] = []
   for (const { location } of weightedLocations) {
+    // 从结果集合中过滤出符合权重的结果
     const filterData = subResults.filter((sub) => {
       const { locations } = sub
       const [min] = locations || []
-      if (typeof min !== 'number')
+      if (typeof min !== 'number') {
         return false
+      }
       const max = locations.length === 1 ? Number.POSITIVE_INFINITY : locations[locations.length - 1]
       return min <= location && location <= max
     })
-    const sub = filterData.reduce<PagefindSubResult | null>((prev, curr) => {
-      if (!prev)
+
+    // 保留 locations 数量最多的
+    const sub = filterData.reduce((prev, curr) => {
+      if (!prev) {
         return curr
+      }
       return prev.locations.length > curr.locations.length ? prev : curr
-    }, null)
-    if (!sub)
+    }, null as SubResult | null)
+
+    if (!sub) {
       continue
+    }
+
     subs.push(sub)
-    if (subs.length >= count)
+
+    if (subs.length >= count) {
       break
+    }
   }
+
+  // 按文章中顺序，排序
   subs.sort((a, b) => {
     const [minA] = a.locations || []
     const [minB] = b.locations || []
-    if (!minA || !minB)
+    if (!minA || !minB) {
       return 0
+    }
     return minA - minB
   })
-  const filterMap = new Map()
-  return subs.map(sub => parseSubResult(sub, anchors, result))
+
+  const filterSet = new Set < string > ()
+  return subs.map(sub => parseSubResult(sub, anchors, result, fuzzyKeywords))
     .filter((v) => {
-      if (filterMap.has(v.meta.title))
+      const title = v.meta.title.join(' > ')
+      if (filterSet.has(title))
         return false
-      filterMap.set(v.meta.title, v)
+      filterSet.add(title)
       return true
     })
 }
 
-function parseSubResult(sub: PagefindSubResult, anchors: PagefindSearchAnchor[], result: PagefindResult): SearchItem {
+function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResult, fuzzyKeywords: FuzzyKeywords): SearchItem {
   const route = sub?.url || result?.url
   const description = sub?.excerpt || result?.excerpt
+
+  // 构造标题
+  // 过滤出合适的标题列表
   const locationsAnchors = anchors?.filter((a) => {
     if (!sub)
       return false
     try {
-      return a.location <= sub.anchor!.location && a.element <= sub.anchor!.element
+      // 直接比较
+      return a.location <= sub.anchor.location && a.element <= sub.anchor.element
     }
-    catch { return false }
+    catch {
+      return false
+    }
   }) || []
   locationsAnchors.reverse()
-  const filteredAnchors = locationsAnchors.reduce<PagefindSearchAnchor[]>((prev, curr) => {
+
+  const filteredAnchors = locationsAnchors.reduce((prev, curr) => {
     const isHave = prev.some(p => p.element === curr.element)
-    if (isHave)
+    if (isHave) {
       return prev
+    }
     prev.unshift(curr)
     return prev
-  }, [])
-  const title = filteredAnchors.length ? filteredAnchors.map(t => t.text!.trim()).filter(v => !!v).join(' > ') : result.meta.title
+  }, [] as Anchor[])
+  // 构造完整的 title 层级 信息
+  const title = filteredAnchors.length
+    ? filteredAnchors.map(t => markTextWithKeywords(t.text.trim(), fuzzyKeywords)).filter(Boolean)
+    : [markTextWithKeywords(result.meta.title, fuzzyKeywords)]
+
   const { base64, date, ...otherMeta } = result.meta
   return {
     route,
     meta: {
       date: date ? +date : undefined,
-      ...decodeBase64AndDeserialize(base64),
+      ...decodeBase64AndDeserialize(base64) as object,
       ...otherMeta,
       title,
       description,
     },
     result
   }
+}
+
+const deduplicateCaseInsensitive = (arr: string[]) => [...new Map(arr.map(s => [s.toLowerCase(), s])).values()]
+type FuzzyKeywords = ReturnType<typeof extractFuzzyKeywordsFromExcerpts>
+function extractFuzzyKeywordsFromExcerpts(results: PagefindResult[], input: string) {
+  const leadingAndTrailingPunctuationsRegexp = /^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu
+  const extract = (tokens: string[]) => deduplicateCaseInsensitive(tokens.map(word =>
+    word.replace(leadingAndTrailingPunctuationsRegexp, '').trim()
+  ))
+  const fuzzyKeywords = {
+    excerptWords: extract(results.flatMap(result => [...result.excerpt.matchAll(/<mark>(.+?)<\/mark>/g).map(matched => matched[1])])),
+    inputTokens: extract(input.trim().split(/\s/)),
+  }
+  return Object.entries(fuzzyKeywords).flatMap(([from, keywords]) =>
+    keywords.map(keyword => ({ keyword, from: from as keyof typeof fuzzyKeywords })))
+}
+
+function markTextWithKeywords(text: string, keywords: FuzzyKeywords) {
+  if (!text)
+    return text
+  text = text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  const segments: (string | { mark: string })[] = [text]
+  for (const { keyword, from } of keywords) {
+    const escapedKeyword = 'escape' in RegExp ? RegExp.escape(keyword) : keyword
+    const regexp = new RegExp(from === 'excerptWords' ? `\\b${escapedKeyword}\\b` : escapedKeyword, 'gi')
+    for (let i = segments.length - 1; i >= 0; i--) {
+      const segment = segments[i]
+      if (typeof segment !== 'string' || segment === '')
+        continue
+      if (regexp.test(segment)) {
+        const splitted = segment.split(regexp).flatMap((seg, i) => i ? [{ mark: segment.match(regexp)![i - 1] }, seg] : [seg])
+        segments.splice(i, 1, ...splitted)
+      }
+    }
+  }
+  return segments.map(segment => typeof segment === 'string' ? segment : `<mark>${segment.mark}</mark>`).join('')
 }
 
 function debounce<T extends (...args: any[]) => any>(func: T, wait: number) {
@@ -276,7 +345,17 @@ function renderList(results: SearchItem[], { showEmptyText = false } = {}) {
           <div command-item data-index="${index}" role="option" aria-selected="false">
             <div class="link">
               <div class="title">
-                <span class="headings">${item.meta.title ? `<i class="prefix"># </i>${item.meta.title}` : ''}</span>
+                <span class="headings">
+                  ${!item.meta.title
+                    ? ''
+                    : `
+                      <i class="prefix">#</i>
+                      ${item.meta.title.map((heading, i) => `
+                        ${i ? '<i class="vpi-chevron-right local-search-icon"></i>' : ''}
+                        <span class="heading">${heading}</span>
+                      `)}
+                    `}
+                </span>
                 ${item.meta.date ? `<span class="date">${formatShowDate(item.meta.date, currentLang)}</span>` : ''}
               </div>
               <div class="des">${item.meta.description || ''}</div>
@@ -387,8 +466,9 @@ const debouncedRealSearch = debounce(async (val: string) => {
     const search = await window.__pagefind__.debouncedSearch(searchText)
     if (search && search.results) {
       const pagefindResults = await Promise.all(search.results.map(r => r.data()))
+      const fuzzyKeywords = extractFuzzyKeywordsFromExcerpts(pagefindResults, searchText)
       const formatted = pagefindResults
-        .map(r => formatPagefindResult(r, currentSearchConfig.pageResultCount || 1))
+        .map(r => formatPagefindResult(r, currentSearchConfig.pageResultCount || 1, fuzzyKeywords))
         .flat()
         .filter((v) => {
           const ignorePublish = currentSearchConfig.ignorePublish ?? false

--- a/packages/vitepress-plugin-pagefind/src/SearchMPADefault.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPADefault.vue
@@ -65,7 +65,7 @@ if (container && btn && mask && dialog) {
   }
 
   btn.addEventListener('click', () => {
-    mask.style.display = 'flex'
+    mask.hidden = false
     if (!window.pagefindInitialized) {
       initPagefind()
       window.pagefindInitialized = true
@@ -74,21 +74,21 @@ if (container && btn && mask && dialog) {
 
   mask.addEventListener('click', (e) => {
     if (e.target === mask) {
-      mask.style.display = 'none'
+      mask.hidden = true
     }
   })
 
   // Close on Escape
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && mask.style.display === 'flex') {
-      mask.style.display = 'none'
+    if (e.key === 'Escape' && !mask.hidden) {
+      mask.hidden = true
     }
   })
 }
 </script>
 
 <template>
-  <div class="blog-search" data-pagefind-ignore="all" :data-base="(site as unknown as typeof site.value).base">
+  <div class="blog-search mpa" data-pagefind-ignore="all" :data-base="(site as unknown as typeof site.value).base">
     <div class="nav-search-btn-wait">
       <span class="svg-icon">
         <svg width="14" height="14" viewBox="0 0 20 20">
@@ -100,7 +100,7 @@ if (container && btn && mask && dialog) {
       </span>
       <span class="search-tip">Search</span>
     </div>
-    <div class="search-dialog-mask" style="display: none;">
+    <div class="search-dialog-mask" hidden>
       <div class="search-dialog">
         <div id="pagefind-search" class="pagefind-search" />
       </div>

--- a/packages/vitepress-plugin-pagefind/src/SearchMPADefault.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPADefault.vue
@@ -4,8 +4,91 @@ import { useData } from 'vitepress'
 const { site } = useData()
 </script>
 
+<script client>
+const container = document.querySelector<HTMLDivElement>('.blog-search')
+const btn = container?.querySelector<HTMLDivElement>('.nav-search-btn-wait')
+const mask = container?.querySelector<HTMLDivElement>('.search-dialog-mask')
+const dialog = container?.querySelector<HTMLDivElement>('.search-dialog')
+
+if (container && btn && mask && dialog) {
+  const base = container.dataset.base || '/'
+
+  // Helper to load script/css
+  const loadResource = (type: 'script' | 'css', url: string) => {
+    return new Promise((resolve, reject) => {
+      const element = document.createElement(type === 'script' ? 'script' : 'link')
+      if (element instanceof HTMLScriptElement) {
+        element.src = url
+        element.onload = resolve
+        element.onerror = reject
+      }
+      else {
+        element.rel = 'stylesheet'
+        element.href = url
+        element.onload = resolve
+        element.onerror = reject
+      }
+      document.head.appendChild(element)
+    })
+  }
+
+  const initPagefind = async () => {
+    try {
+      if (!window.PagefindUI) {
+        // Join paths safely-ish
+        const cssUrl = `${base}pagefind/pagefind-ui.css`.replace(/\/+/g, '/')
+        const jsUrl = `${base}pagefind/pagefind-ui.js`.replace(/\/+/g, '/')
+
+        await Promise.all([
+          loadResource('css', cssUrl),
+          loadResource('script', jsUrl)
+        ])
+      }
+
+      // eslint-disable-next-line no-new
+      new window.PagefindUI!({
+        element: '#pagefind-search',
+        showSubResults: true,
+        showImages: false,
+        translations: {
+          placeholder: 'Search Docs'
+        }
+      })
+    }
+    catch (e) {
+      console.error('Failed to load Pagefind UI:', e)
+      const searchContainer = document.getElementById('pagefind-search')
+      if (searchContainer) {
+        searchContainer.innerHTML = '<p style="color:var(--vp-c-danger); text-align:center; padding: 20px;">Search index not found. Please build the site first.</p>'
+      }
+    }
+  }
+
+  btn.addEventListener('click', () => {
+    mask.style.display = 'flex'
+    if (!window.pagefindInitialized) {
+      initPagefind()
+      window.pagefindInitialized = true
+    }
+  })
+
+  mask.addEventListener('click', (e) => {
+    if (e.target === mask) {
+      mask.style.display = 'none'
+    }
+  })
+
+  // Close on Escape
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && mask.style.display === 'flex') {
+      mask.style.display = 'none'
+    }
+  })
+}
+</script>
+
 <template>
-  <div class="blog-search" data-pagefind-ignore="all" :data-base="site.base">
+  <div class="blog-search" data-pagefind-ignore="all" :data-base="(site as unknown as typeof site.value).base">
     <div class="nav-search-btn-wait">
       <span class="svg-icon">
         <svg width="14" height="14" viewBox="0 0 20 20">
@@ -19,7 +102,7 @@ const { site } = useData()
     </div>
     <div class="search-dialog-mask" style="display: none;">
       <div class="search-dialog">
-        <div id="pagefind-search" class="pagefind-search"></div>
+        <div id="pagefind-search" class="pagefind-search" />
       </div>
     </div>
   </div>
@@ -31,6 +114,7 @@ const { site } = useData()
   display: flex;
   padding-left: 32px;
 }
+
 .nav-search-btn-wait {
   cursor: pointer;
   display: flex;
@@ -43,15 +127,18 @@ const { site } = useData()
   border-radius: 8px;
   transition: .2s border;
 }
+
 .nav-search-btn-wait:hover {
   border: 1px solid var(--vp-c-brand-1);
 }
+
 .nav-search-btn-wait .search-tip {
   color: #909399;
   font-size: 12px;
   padding-left: 8px;
   padding-right: 16px;
 }
+
 .svg-icon {
   display: flex;
   align-items: center;
@@ -62,10 +149,12 @@ const { site } = useData()
     flex: 0;
     padding-left: 0;
   }
+
   .nav-search-btn-wait {
     background-color: transparent;
     padding: 0 4px;
   }
+
   .search-tip {
     display: none;
   }
@@ -84,6 +173,7 @@ const { site } = useData()
   align-items: flex-start;
   padding-top: 10vh;
 }
+
 .search-dialog {
   background-color: var(--vp-c-bg);
   width: 90%;
@@ -101,9 +191,11 @@ const { site } = useData()
   color: var(--vp-c-text-1);
   border: 1px solid var(--vp-c-divider);
 }
+
 :deep(.pagefind-ui__result-title) {
   color: var(--vp-c-brand-1);
 }
+
 :deep(.pagefind-ui__result-excerpt) {
   color: var(--vp-c-text-2);
 }
@@ -112,83 +204,3 @@ const { site } = useData()
 <style lang="css">
 @import './assets/scss/search.css';
 </style>
-
-<script client>
-  const container = document.querySelector('.blog-search');
-  const btn = container?.querySelector('.nav-search-btn-wait');
-  const mask = container?.querySelector('.search-dialog-mask');
-  const dialog = container?.querySelector('.search-dialog');
-  
-  if (container && btn && mask && dialog) {
-    const base = container.dataset.base || '/';
-    
-    // Helper to load script/css
-    const loadResource = (type, url) => {
-      return new Promise((resolve, reject) => {
-        const element = document.createElement(type === 'script' ? 'script' : 'link');
-        if (type === 'script') {
-          element.src = url;
-          element.onload = resolve;
-          element.onerror = reject;
-        } else {
-          element.rel = 'stylesheet';
-          element.href = url;
-          element.onload = resolve;
-          element.onerror = reject;
-        }
-        document.head.appendChild(element);
-      });
-    };
-
-    const initPagefind = async () => {
-      try {
-        if (!window.PagefindUI) {
-          // Join paths safely-ish
-          const cssUrl = `${base}pagefind/pagefind-ui.css`.replace(/\/+/g, '/');
-          const jsUrl = `${base}pagefind/pagefind-ui.js`.replace(/\/+/g, '/');
-          
-          await Promise.all([
-            loadResource('css', cssUrl),
-            loadResource('script', jsUrl)
-          ]);
-        }
-        
-        new window.PagefindUI({
-          element: "#pagefind-search",
-          showSubResults: true,
-          showImages: false,
-          translations: {
-            placeholder: "Search Docs"
-          }
-        });
-      } catch (e) {
-        console.error('Failed to load Pagefind UI:', e);
-        const searchContainer = document.getElementById('pagefind-search');
-        if (searchContainer) {
-           searchContainer.innerHTML = '<p style="color:var(--vp-c-danger); text-align:center; padding: 20px;">Search index not found. Please build the site first.</p>';
-        }
-      }
-    };
-
-    btn.addEventListener('click', () => {
-      mask.style.display = 'flex';
-      if (!window.pagefindInitialized) {
-         initPagefind();
-         window.pagefindInitialized = true;
-      }
-    });
-
-    mask.addEventListener('click', (e) => {
-      if (e.target === mask) {
-        mask.style.display = 'none';
-      }
-    });
-    
-    // Close on Escape
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && mask.style.display === 'flex') {
-        mask.style.display = 'none';
-      }
-    });
-  }
-</script>

--- a/packages/vitepress-plugin-pagefind/src/SearchMPADefault.vue
+++ b/packages/vitepress-plugin-pagefind/src/SearchMPADefault.vue
@@ -4,7 +4,7 @@ import { useData } from 'vitepress'
 const { site } = useData()
 </script>
 
-<script client>
+<script client lang="ts">
 const container = document.querySelector<HTMLDivElement>('.blog-search')
 const btn = container?.querySelector<HTMLDivElement>('.nav-search-btn-wait')
 const mask = container?.querySelector<HTMLDivElement>('.search-dialog-mask')

--- a/packages/vitepress-plugin-pagefind/src/assets/scss/algolia.scss
+++ b/packages/vitepress-plugin-pagefind/src/assets/scss/algolia.scss
@@ -29,6 +29,10 @@
     overscroll-behavior: contain;
     transition: 100ms ease;
     transition-property: height;
+
+    @supports (height: min(1px, 1px)) {
+      height: min(var(--command-list-height), 360px);
+    }
   }
 
   [command-item] {

--- a/packages/vitepress-plugin-pagefind/src/assets/scss/algolia.scss
+++ b/packages/vitepress-plugin-pagefind/src/assets/scss/algolia.scss
@@ -31,7 +31,9 @@
     transition-property: height;
 
     @supports (height: min(1px, 1px)) {
-      height: min(var(--command-list-height), 360px);
+      @media screen and (min-width: 561px) {
+        height: min(var(--command-list-height), 360px);
+      }
     }
   }
 

--- a/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
+++ b/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
@@ -162,6 +162,12 @@ div [command-dialog-footer] {
   transition-property: height;
   scrollbar-gutter: stable;
 }
+@supports (height: min(1px, 1px)) {
+  .algolia [command-list] {
+    /* 使用 min() 声明 height 属性，而不是直接用 max-height（额外声明了不影响），可以避免高度过渡动画的异常。 */
+    height: min(var(--command-list-height), 360px);
+  }
+}
 .algolia .detail-list [command-item] {
   min-height: 56px;
   max-height: 112px;
@@ -171,10 +177,12 @@ div [command-dialog-footer] {
 .algolia .detail-list [command-item] .des {
   word-break: break-all;
   white-space: wrap;
-  margin-top: 6px;
+  margin-top: 3px;
   display: -webkit-box;
   -webkit-line-clamp: 3;
+  line-clamp: 3;
   -webkit-box-orient: vertical;
+  line-height: 21px;
 }
 .algolia [command-item] {
   position: relative;
@@ -457,7 +465,8 @@ div[command-item] {
   overflow: hidden;
   word-break: keep-all;
   white-space: nowrap;
-  transition: margin 150ms, opacity 150ms;
+  transition: 150ms;
+  transition-property: margin, opacity, line-height;
   opacity: 0.5;
 }
 .search-dialog div[command-item] .headings {

--- a/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
+++ b/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
@@ -163,9 +163,11 @@ div [command-dialog-footer] {
   scrollbar-gutter: stable;
 }
 @supports (height: min(1px, 1px)) {
-  .algolia [command-list] {
-    /* 使用 min() 声明 height 属性，而不是直接用 max-height（额外声明了不影响），可以避免高度过渡动画的异常。 */
-    height: min(var(--command-list-height), 360px);
+  @media screen and (min-width: 561px) {
+    .algolia [command-list] {
+      /* 使用 min() 声明 height 属性，而不是直接用 max-height（额外声明了不影响），可以避免高度过渡动画的异常。 */
+      height: min(var(--command-list-height), 360px);
+    }
   }
 }
 .algolia .detail-list [command-item] {
@@ -397,7 +399,7 @@ div [command-dialog-footer] {
     font-size: 14px;
   }
   .algolia [command-list] {
-    max-height: calc(100vh - 120px);
+    max-height: calc(100vh - 108px);
   }
   .algolia [command-dialog-body] {
     height: 100%;

--- a/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
+++ b/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
@@ -45,6 +45,7 @@
   --blue11: hsl(211, 100%, 43.2%);
   --blue12: hsl(211, 100%, 15%);
 }
+
 .dark {
   --app-bg: var(--gray1);
   --app-text: #ffffff;
@@ -97,6 +98,7 @@ div [command-dialog-mask] {
   width: 100vw;
   z-index: 200;
 }
+
 div [command-dialog-wrapper] {
   position: relative;
   background: var(--gray2);
@@ -106,6 +108,7 @@ div [command-dialog-wrapper] {
   margin: 20vh auto auto;
   max-width: 560px;
 }
+
 div [command-dialog-footer] {
   border-top: 1px solid var(--gray6);
   align-items: center;
@@ -125,6 +128,7 @@ div [command-dialog-footer] {
   z-index: 300;
   font-size: 12px;
 }
+
 .algolia [command-input] {
   font-family: var(--font-sans);
   width: 100%;
@@ -136,6 +140,7 @@ div [command-dialog-footer] {
   caret-color: var(--vcp-c-brand);
   margin: 0;
 }
+
 @supports (caret-animation: manual) {
   .algolia [command-input] {
     caret-animation: manual;
@@ -145,14 +150,17 @@ div [command-dialog-footer] {
     animation: algolia-command-input-caret-animation 500ms infinite cubic-bezier(1, 0, 0, 1) alternate;
   }
 }
+
 @keyframes algolia-command-input-caret-animation {
   to {
     caret-color: transparent;
   }
 }
+
 .algolia [command-input]::placeholder {
   color: var(--gray9);
 }
+
 .algolia [command-list] {
   height: var(--command-list-height);
   max-height: 360px;
@@ -162,6 +170,7 @@ div [command-dialog-footer] {
   transition-property: height;
   scrollbar-gutter: stable;
 }
+
 @supports (height: min(1px, 1px)) {
   @media screen and (min-width: 561px) {
     .algolia [command-list] {
@@ -170,12 +179,14 @@ div [command-dialog-footer] {
     }
   }
 }
+
 .algolia .detail-list [command-item] {
   min-height: 56px;
   max-height: 112px;
   padding: 10px 16px;
   height: auto;
 }
+
 .algolia .detail-list [command-item] .des {
   word-break: break-all;
   white-space: wrap;
@@ -186,6 +197,7 @@ div [command-dialog-footer] {
   -webkit-box-orient: vertical;
   line-height: 21px;
 }
+
 .algolia [command-item] {
   position: relative;
   content-visibility: auto;
@@ -207,42 +219,52 @@ div [command-dialog-footer] {
   margin-top: 6px;
   border: solid 2px var(--vp-c-divider);
 }
+
 .algolia [command-item]:first-child {
   margin-top: 0;
 }
-.algolia [command-item][aria-selected="true"],
-.algolia [command-item]:is(:hover, :focus-visible) {
+
+.algolia [command-item]:is(:hover, :focus-visible, [aria-selected="true"]) {
   border-color: var(--vp-c-brand-1);
 }
-.algolia [command-item][aria-selected="true"] .headings,
-.algolia [command-item]:is(:hover, :focus-visible) .headings {
+
+.algolia [command-item]:is(:hover, :focus-visible, [aria-selected="true"]) .headings {
   color: var(--vp-c-brand-1);
 }
-.algolia [command-item][aria-selected="true"] .des,
-.algolia [command-item]:is(:hover, :focus-visible) .des,
-.algolia [command-item]:is(:hover, :focus-visible) .date {
+
+.algolia [command-item]:is(:hover, :focus-visible, [aria-selected="true"]) .des,
+.algolia [command-item]:is(:hover, :focus-visible, [aria-selected="true"]) .date {
   opacity: 1;
 }
+
 .algolia [command-item][aria-selected="true"] [command-linear-shortcuts],
 .algolia [command-item]:hover [command-linear-shortcuts] {
   display: flex;
   margin-left: auto;
   gap: 8px;
 }
+
 .algolia [command-item][aria-selected="true"] [command-linear-shortcuts] kbd,
 .algolia [command-item]:hover [command-linear-shortcuts] kbd {
   font-family: var(--font-sans);
   font-size: 13px;
   color: var(--gray11);
 }
+
+.algolia [command-item][aria-selected="true"]:is(:hover, :focus-visible) {
+  background: var(--gray3);
+}
+
 .algolia [command-item]:is(:hover, :focus-visible):active {
   background: var(--gray4);
 }
+
 .algolia [command-item] svg {
   width: 16px;
   height: 16px;
   color: var(--gray10);
 }
+
 .algolia [command-list][data-empty-text]:empty::after,
 .algolia [command-list-sizer][data-empty-text]:empty::after {
   content: attr(data-empty-text);
@@ -255,6 +277,7 @@ div [command-dialog-footer] {
   color: var(--gray11);
   padding-bottom: 12px;
 }
+
 .algolia [command-empty=''] {
   font-size: 14px;
   display: flex;
@@ -265,6 +288,7 @@ div [command-dialog-footer] {
   color: var(--gray11);
   padding-bottom: 12px;
 }
+
 .algolia [command-loading=""] {
   font-size: 14px;
   display: flex;
@@ -275,6 +299,7 @@ div [command-dialog-footer] {
   white-space: pre-wrap;
   color: var(--gray11);
 }
+
 .algolia [command-loading-spinner],
 .algolia [command-overlay] [command-overlay-spinner] {
   flex-shrink: 0;
@@ -285,26 +310,27 @@ div [command-dialog-footer] {
   border-top-color: var(--vp-c-brand-1, var(--vp-c-brand, #3eaf7c));
   animation: algolia-mask-spin 0.8s linear infinite;
 }
+
 .algolia .search-dialog {
   position: relative;
 }
+
 .algolia [command-overlay] {
   position: absolute;
   inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: radial-gradient(
-    ellipse at center,
-    color-mix(in srgb, var(--vp-c-bg) 92%, transparent) 0%,
-    color-mix(in srgb, var(--vp-c-bg) 78%, transparent) 32%,
-    color-mix(in srgb, var(--vp-c-bg) 45%, transparent) 65%,
-    color-mix(in srgb, var(--vp-c-bg) 20%, transparent) 100%
-  );
+  background: radial-gradient(ellipse at center,
+      color-mix(in srgb, var(--vp-c-bg) 92%, transparent) 0%,
+      color-mix(in srgb, var(--vp-c-bg) 78%, transparent) 32%,
+      color-mix(in srgb, var(--vp-c-bg) 45%, transparent) 65%,
+      color-mix(in srgb, var(--vp-c-bg) 20%, transparent) 100%);
   z-index: 2;
   pointer-events: auto;
   animation: algolia-mask-fade-in 0.2s ease-out;
 }
+
 .algolia [command-overlay] [command-overlay-text] {
   display: inline-flex;
   align-items: center;
@@ -313,22 +339,35 @@ div [command-dialog-footer] {
   font-size: 14px;
   font-weight: 500;
 }
+
 @keyframes algolia-mask-spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
+
 @keyframes algolia-mask-fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
 }
+
 .algolia [command-dialog-mask] {
   background-color: var(--vp-backdrop-bg-color);
 }
+
 .algolia [command-dialog-header] {
   padding: 12px;
 }
+
 .algolia [command-dialog-body] {
   padding: 0 12px;
 }
+
 .algolia [command-dialog-footer] {
   align-items: center;
   border-radius: 0 0 8px 8px;
@@ -346,12 +385,14 @@ div [command-dialog-footer] {
   width: 100%;
   z-index: 300;
 }
+
 @media screen and (min-width: 561px) {
   .algolia [command-dialog-footer].no-search-result {
     box-shadow: none;
     border-top: none;
   }
 }
+
 .algolia [command-group-heading] {
   color: var(--vcp-c-brand);
   font-size: 0.85em;
@@ -363,6 +404,7 @@ div [command-dialog-footer] {
   z-index: 10;
   width: 100%;
 }
+
 .algolia [command-group-items] {
   padding-bottom: 12px;
 }
@@ -374,6 +416,7 @@ div [command-dialog-footer] {
   margin: 0;
   padding: 0;
 }
+
 @media screen and (max-width: 560px) {
   .algolia .command-palette-commands {
     display: none;
@@ -388,40 +431,50 @@ div [command-dialog-footer] {
     display: flex;
     flex-direction: column;
   }
+
   .algolia [command-dialog-footer] {
     justify-content: center;
     border-radius: 0;
   }
+
   .algolia [command-input] {
     padding: 6px 4px;
     font-size: 14px;
   }
+
   .algolia [command-list] {
     max-height: calc(100vh - 108px);
   }
+
   .algolia [command-dialog-body] {
     height: 100%;
   }
 }
+
 .algolia .command-palette-commands li {
   display: flex;
   align-items: center;
 }
+
 .algolia .command-palette-commands li:not(:last-of-type) {
   margin-right: 0.8em;
 }
+
 .algolia .command-palette-logo a {
   display: flex;
   align-items: center;
   gap: 8px;
 }
+
 .dark .algolia .command-palette-logo svg {
   filter: invert(1) hue-rotate(180deg);
 }
+
 .algolia .command-palette-logo svg {
   height: 24px;
   width: 24px;
 }
+
 .algolia .command-palette-commands-key {
   align-items: center;
   background: var(--gray3);
@@ -435,21 +488,26 @@ div [command-dialog-footer] {
   border: 0;
   width: 20px;
 }
+
 .dark .algolia [command-dialog-footer] {
   box-shadow: none;
 }
+
 div[command-group] {
   display: block !important;
 }
+
 div[command-item] {
   all: unset;
   width: 100%;
   box-sizing: border-box;
   display: flex !important;
 }
+
 .search-dialog div[command-item] > div.link {
   width: 100%;
 }
+
 .search-dialog div[command-item] .title {
   display: flex;
   justify-content: space-between;
@@ -458,6 +516,7 @@ div[command-item] {
 .search-dialog div[command-item] .title i.prefix {
   color: var(--vp-c-brand-1);
   opacity: 0.5;
+  margin-inline-end: 1ex;
 }
 
 .search-dialog div[command-item] .des {
@@ -469,23 +528,39 @@ div[command-item] {
   transition-property: margin, opacity, line-height;
   opacity: 0.5;
 }
+
 .search-dialog div[command-item] .headings {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   display: inline-block;
   transition: color 150ms;
+  line-height: 24px;
+}
+
+.search-dialog div[command-item] .vpi-chevron-right {
+  display: inline-block;
+  font-size: 13px;
+  height: 16px;
+  vertical-align: text-bottom;
+  margin-inline: 4px 2px;
 }
 
 .search-dialog div[command-item] .date {
   min-width: 86px;
   text-align: right;
   opacity: 0.5;
+  transition-property: opacity;
 }
+
 .search-dialog div[command-item] mark {
   background: none;
   color: var(--vp-c-brand-1);
-	box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+.algolia [command-item]:is(:hover, :focus-visible, [aria-selected="true"]) .headings mark {
+  color: var(--vp-c-brand-3);
 }
 
 label.search-icon {

--- a/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
+++ b/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
@@ -185,7 +185,7 @@ div [command-dialog-footer] {
   max-height: 56px;
   font-size: 14px;
   display: flex;
-  align-items: center;
+  align-items: start;
   gap: 12px;
   padding: 0 16px;
   color: var(--gray12);
@@ -337,6 +337,12 @@ div [command-dialog-footer] {
   user-select: none;
   width: 100%;
   z-index: 300;
+}
+@media screen and (min-width: 561px) {
+  .algolia [command-dialog-footer].no-search-result {
+    box-shadow: none;
+    border-top: none;
+  }
 }
 .algolia [command-group-heading] {
   color: var(--vcp-c-brand);

--- a/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
+++ b/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
@@ -169,6 +169,7 @@ div [command-dialog-footer] {
   transition: 100ms ease;
   transition-property: height;
   scrollbar-gutter: stable;
+  scroll-behavior: smooth;
 }
 
 @supports (height: min(1px, 1px)) {

--- a/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
+++ b/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
@@ -211,18 +211,16 @@ div [command-dialog-footer] {
   margin-top: 0;
 }
 .algolia [command-item][aria-selected="true"],
-.algolia [command-item]:hover,
-.algolia [command-item]:focus-visible {
+.algolia [command-item]:is(:hover, :focus-visible) {
   border-color: var(--vp-c-brand-1);
 }
 .algolia [command-item][aria-selected="true"] .headings,
-.algolia [command-item]:hover .headings,
-.algolia [command-item]:focus-visible .headings {
+.algolia [command-item]:is(:hover, :focus-visible) .headings {
   color: var(--vp-c-brand-1);
 }
 .algolia [command-item][aria-selected="true"] .des,
-.algolia [command-item]:hover .des,
-.algolia [command-item]:focus-visible .des {
+.algolia [command-item]:is(:hover, :focus-visible) .des,
+.algolia [command-item]:is(:hover, :focus-visible) .date {
   opacity: 1;
 }
 .algolia [command-item][aria-selected="true"] [command-linear-shortcuts],
@@ -482,10 +480,12 @@ div[command-item] {
 .search-dialog div[command-item] .date {
   min-width: 86px;
   text-align: right;
+  opacity: 0.5;
 }
 .search-dialog div[command-item] mark {
   background: none;
   color: var(--vp-c-brand-1);
+	box-decoration-break: clone;
 }
 
 label.search-icon {

--- a/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
+++ b/packages/vitepress-plugin-pagefind/src/assets/scss/search.css
@@ -585,3 +585,30 @@ label.search-icon {
   opacity: 0;
   translate: 0 -1rem;
 }
+
+.mpa .algolia [command-dialog-mask],
+.mpa .algolia [command-dialog-wrapper] {
+  transition: 250ms;
+  transition-behavior: allow-discrete;
+  transition-property: translate, opacity, display;
+}
+
+@starting-style {
+  .mpa .algolia [command-dialog-mask],
+  .mpa .algolia [command-dialog-wrapper] {
+    opacity: 0;
+  }
+
+  .mpa .algolia [command-dialog-wrapper] {
+    translate: 0 -1rem;
+  }
+}
+
+.mpa .algolia [command-dialog-mask][hidden],
+.mpa .algolia [command-dialog-mask][hidden] [command-dialog-wrapper] {
+  opacity: 0;
+}
+
+.mpa .algolia [command-dialog-mask][hidden] [command-dialog-wrapper] {
+  translate: 0 -1rem;
+}

--- a/packages/vitepress-plugin-pagefind/src/command-palette/CommandDialog.vue
+++ b/packages/vitepress-plugin-pagefind/src/command-palette/CommandDialog.vue
@@ -14,6 +14,7 @@ defineOptions({
 const props = defineProps<{
   visible: boolean
   theme: string
+  footerClass?: string | Record<string, unknown>
 }>()
 
 const emit = defineEmits<{
@@ -49,7 +50,7 @@ onBeforeUnmount(resetStore)
               <div command-dialog-body>
                 <slot name="body" />
               </div>
-              <div v-if="$slots.footer" command-dialog-footer>
+              <div v-if="$slots.footer" command-dialog-footer :class="props.footerClass">
                 <slot name="footer" />
               </div>
             </div>

--- a/packages/vitepress-plugin-pagefind/src/command-palette/CommandInput.vue
+++ b/packages/vitepress-plugin-pagefind/src/command-palette/CommandInput.vue
@@ -1,10 +1,9 @@
 <script lang="ts">
-import { computed, ref, watchEffect } from 'vue'
+import { ref, watchEffect } from 'vue'
 </script>
 
 <script lang="ts" setup>
-import type { CommandInputEmits, CommandInputProps } from './types'
-import { useCommandState } from './useCommandState'
+import type { CommandInputProps } from './types'
 
 defineOptions({
   name: 'Command.Input',
@@ -12,19 +11,8 @@ defineOptions({
 
 defineProps<CommandInputProps>()
 
-const emit = defineEmits<CommandInputEmits>()
-
 const inputRef = ref<HTMLInputElement | null>(null)
-const { search } = useCommandState()
-const localSearch = computed(() => search.value)
-
-function handleInput(e: Event) {
-  const event = e as InputEvent
-  const input = e.target as HTMLInputElement
-  search.value = input?.value
-  emit('input', event)
-  emit('update:value', search.value)
-}
+const localSearch = defineModel({ default: '' })
 
 watchEffect(() => {
   inputRef.value?.focus()
@@ -40,6 +28,7 @@ defineExpose({
 <template>
   <input
     ref="inputRef"
+    v-model="localSearch"
     command-input=""
     auto-focus
     auto-complete="off"
@@ -49,7 +38,5 @@ defineExpose({
     role="combobox"
     :aria-expanded="true"
     :placeholder="placeholder"
-    :value="localSearch"
-    @input="handleInput"
   >
 </template>

--- a/packages/vitepress-plugin-pagefind/src/command-palette/CommandInput.vue
+++ b/packages/vitepress-plugin-pagefind/src/command-palette/CommandInput.vue
@@ -12,7 +12,7 @@ defineOptions({
 defineProps<CommandInputProps>()
 
 const inputRef = ref<HTMLInputElement | null>(null)
-const localSearch = defineModel({ default: '' })
+const localSearch = defineModel<string>({ default: '' })
 
 watchEffect(() => {
   inputRef.value?.focus()

--- a/packages/vitepress-plugin-pagefind/src/command-palette/CommandList.vue
+++ b/packages/vitepress-plugin-pagefind/src/command-palette/CommandList.vue
@@ -57,7 +57,6 @@ watchEffect(() => {
     })
     observer.observe(sizer)
     wrapper.addEventListener('transitionend', (e) => {
-      console.log(e)
       if (e.propertyName === 'height') {
         clearTimeout(timeoutId)
         restoreScroll()

--- a/packages/vitepress-plugin-pagefind/src/command-palette/CommandList.vue
+++ b/packages/vitepress-plugin-pagefind/src/command-palette/CommandList.vue
@@ -17,6 +17,10 @@ const { rerenderList } = useCommandEvent()
 
 const listRef = ref<HTMLDivElement>()
 const heightRef = ref<HTMLDivElement>()
+const isRequestedScrollToTop = ref(false)
+function requestScrollToTop() {
+  isRequestedScrollToTop.value = true
+}
 
 let observer: ResizeObserver | null = null
 let sizer: HTMLDivElement | undefined
@@ -27,19 +31,19 @@ watchEffect(() => {
   let animationFrame: number
   let timeoutId: ReturnType<typeof setTimeout> | undefined
   if (sizer && wrapper) {
-    const onTransitionEnd = (e: TransitionEvent) => {
-      if (e.propertyName === 'height') {
-        clearTimeout(timeoutId)
-        wrapper.style.overflowY = ''
-      }
+    const wrapperScrollAborter = new AbortController()
+    const transitionEndAborter = new AbortController()
+    wrapperScrollAborter.signal.addEventListener('abort', () => isRequestedScrollToTop.value = false)
+    const restoreScroll = () => {
+      wrapper.style.overflowY = ''
     }
     observer = new ResizeObserver(() => {
       // 避免过渡时短暂出现的滚动条。
-      wrapper.style.overflowY = 'hidden'
+      wrapper.style.overflowY = 'clip'
       clearTimeout(timeoutId)
       // 如果下方的 transitionend 异常超时导致未能正确触发恢复 overflow，则执行该 setTimeout 第二道保险。
       timeoutId = setTimeout(() => {
-        wrapper.style.overflowY = ''
+        restoreScroll()
       }, 500)
       animationFrame = requestAnimationFrame(() => {
         const height = sizer?.offsetHeight
@@ -52,21 +56,37 @@ watchEffect(() => {
       })
     })
     observer.observe(sizer)
-    wrapper.addEventListener('transitionend', onTransitionEnd)
+    wrapper.addEventListener('transitionend', (e) => {
+      console.log(e)
+      if (e.propertyName === 'height') {
+        clearTimeout(timeoutId)
+        restoreScroll()
+      }
+    }, { signal: transitionEndAborter.signal })
+    wrapper.addEventListener('scroll', (e) => {
+      if (isRequestedScrollToTop.value) {
+        e.preventDefault()
+        wrapper.scrollTo({ top: 0, behavior: 'instant' })
+        isRequestedScrollToTop.value = false
+      }
+    }, { signal: wrapperScrollAborter.signal })
 
     return () => {
       cancelAnimationFrame(animationFrame)
       clearTimeout(timeoutId)
       observer?.unobserve(sizer!)
-      wrapper.removeEventListener('transitionend', onTransitionEnd)
+      transitionEndAborter.abort()
+      wrapperScrollAborter.abort()
     }
   }
 })
 
 onBeforeUnmount(() => {
   if (observer !== null && sizer)
-    observer.unobserve(sizer)
+    observer.disconnect()
 })
+
+defineExpose({ requestScrollToTop })
 </script>
 
 <template>

--- a/packages/vitepress-plugin-pagefind/src/command-palette/CommandRoot.vue
+++ b/packages/vitepress-plugin-pagefind/src/command-palette/CommandRoot.vue
@@ -16,10 +16,10 @@ const props = withDefaults(defineProps<CommandRootProps>(), {
 
 const emit = defineEmits<CommandRootEmits>()
 
-const ITEM_SELECTOR = '[command-item=""]'
+const ITEM_SELECTOR = '[command-item]'
 const ITEM_KEY_SELECTOR = 'command-item-key'
-const GROUP_SELECTOR = '[command-group=""]'
-const GROUP_HEADING_SELECTOR = '[command-group-heading=""]'
+const GROUP_SELECTOR = '[command-group]'
+const GROUP_HEADING_SELECTOR = '[command-group-heading]'
 const VALID_ITEM_SELECTOR = `${ITEM_SELECTOR}:not([aria-disabled="true"])`
 const SELECTED_ITEM_SELECTOR = `${ITEM_SELECTOR}[aria-selected="true"]`
 const SELECT_EVENT = 'command-item-select'

--- a/packages/vitepress-plugin-pagefind/src/command-palette/types.ts
+++ b/packages/vitepress-plugin-pagefind/src/command-palette/types.ts
@@ -24,7 +24,7 @@ export interface CommandItemEmits {
 
 export interface CommandInputProps {
   placeholder?: string
-  value?: string
+  modelValue?: string
 }
 
 export interface CommandInputEmits {

--- a/packages/vitepress-plugin-pagefind/src/index.ts
+++ b/packages/vitepress-plugin-pagefind/src/index.ts
@@ -18,8 +18,8 @@ function getDirname() {
 }
 
 const aliasSearchVueFile = `${getDirname()}/../src/Search.vue`
-const aliasSearchVueFileMPA = `${getDirname()}/../src/SearchMPA.vue`
-const aliasSearchVueFileMPADefault = `${getDirname()}/../src/SearchMPADefault.vue`
+const aliasSearchVueFileMPA = `${getDirname()}/../dist/SearchMPA.vue`
+const aliasSearchVueFileMPADefault = `${getDirname()}/../dist/SearchMPADefault.vue`
 
 export function meta2string(frontmatter: Record<string, any>) {
   return `base64:${Buffer.from(encodeURIComponent(JSON.stringify(frontmatter))).toString('base64')}`

--- a/packages/vitepress-plugin-pagefind/src/index.ts
+++ b/packages/vitepress-plugin-pagefind/src/index.ts
@@ -33,13 +33,13 @@ export function pagefindPlugin(
 
   let resolveConfig: any
   let vitepressConfig: SiteConfig
-  let dynamicRoutes: SiteConfig['dynamicRoutes']
+  let dynamicRoutes: SiteConfig['dynamicRoutes'] | { routes: SiteConfig['dynamicRoutes'] }
   const pluginOps: PluginOption = {
     name: 'vitepress-plugin-pagefind',
-    config: (cfg) => {
-      // @ts-expect-error
+    config: (_config) => {
+      const config = _config as typeof _config & { vitepress: SiteConfig }
       // MPA 模式下使用 MPA 组件
-      const isMPA = !!cfg.vitepress.mpa
+      const isMPA = !!config.vitepress.mpa
       const isMPADefaultUI = searchConfig.mpaDefaultUI
       return {
         resolve: {
@@ -49,7 +49,8 @@ export function pagefindPlugin(
         }
       }
     },
-    async configResolved(config: any) {
+    async configResolved(_config) {
+      const config = _config as typeof _config & { vitepress: SiteConfig }
       if (searchConfig.manual) {
         return
       }
@@ -71,7 +72,7 @@ export function pagefindPlugin(
       }
       // 添加生成索引的方法
       const selfBuildEnd = vitepressConfig.buildEnd
-      vitepressConfig.buildEnd = async (siteConfig: any) => {
+      vitepressConfig.buildEnd = async (siteConfig) => {
         const okMark = '\x1B[32m✓\x1B[0m'
         console.time(`${okMark} generating pagefind Indexing...`)
         // 调用自己的
@@ -115,9 +116,7 @@ export function pagefindPlugin(
       // 兼容 动态 路由
       const isWindows = process.platform === 'win32'
       const fullPath = isWindows ? `${protocol}${pathname}` : pathname
-      // @ts-expect-error
       const _dynamicRoutes = Array.isArray(dynamicRoutes) ? dynamicRoutes : (dynamicRoutes?.routes || [])
-      // @ts-expect-error
       const dynamicRoute = _dynamicRoutes.find(route => fullPath.toLowerCase() === route.fullPath.toLowerCase())
       const isDynamicRoute = !!dynamicRoute
       const filepath = isDynamicRoute ? joinPath(vitepressConfig.srcDir, `/${dynamicRoute.route}`) : pathname

--- a/packages/vitepress-plugin-pagefind/src/index.ts
+++ b/packages/vitepress-plugin-pagefind/src/index.ts
@@ -81,11 +81,18 @@ export function pagefindPlugin(
         console.timeEnd(`${okMark} generating pagefind Indexing...`)
       }
 
+      const isMPA = !!vitepressConfig.mpa
       // 通过 head 添加额外的脚本注入
       const selfTransformHead = vitepressConfig.transformHead
       vitepressConfig.transformHead = async (ctx) => {
         const selfHead = (await Promise.resolve(selfTransformHead?.(ctx))) || []
-        return selfHead.concat(getPagefindHead(ctx.siteData.base) as HeadConfig[])
+        return selfHead.concat(getPagefindHead(ctx.siteData.base) as HeadConfig[], isMPA
+          ? [[
+              'script',
+              { id: 'check-mac-os' },
+              'document.documentElement.classList.toggle(\'mac\', /Mac|iPhone|iPod|iPad/i.test(navigator.platform))'
+            ]]
+          : [])
       }
     },
     resolveId(id: string) {

--- a/packages/vitepress-plugin-pagefind/src/search.ts
+++ b/packages/vitepress-plugin-pagefind/src/search.ts
@@ -134,18 +134,19 @@ export function extractFuzzyKeywordsFromExcerpts(results: PagefindResult[], inpu
   const extract = (tokens: string[]) => deduplicateCaseInsensitive(tokens.map(word =>
     word.replace(leadingAndTrailingPunctuationsRegexp, '').trim()
   ))
-  return {
+  const fuzzyKeywords = {
     excerptWords: extract(results.flatMap(result => [...result.excerpt.matchAll(/<mark>(.+?)<\/mark>/g).map(matched => matched[1])])),
     inputTokens: extract(input.trim().split(/\s/)),
   }
+  return Object.entries(fuzzyKeywords).flatMap(([from, keywords]) =>
+    keywords.map(keyword => ({ keyword, from: from as keyof typeof fuzzyKeywords })))
 }
 
-function markTextWithKeywords(text: string, fuzzyKeywords: FuzzyKeywords) {
+function markTextWithKeywords(text: string, keywords: FuzzyKeywords) {
   if (!text)
     return text
   text = text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
   const segments: (string | { mark: string })[] = [text]
-  const keywords = Object.entries(fuzzyKeywords).flatMap(([from, keywords]) => keywords.map(keyword => ({ keyword, from })))
   for (const { keyword, from } of keywords) {
     const escapedKeyword = 'escape' in RegExp ? RegExp.escape(keyword) : keyword
     const regexp = new RegExp(from === 'excerptWords' ? `\\b${escapedKeyword}\\b` : escapedKeyword, 'gi')

--- a/packages/vitepress-plugin-pagefind/src/search.ts
+++ b/packages/vitepress-plugin-pagefind/src/search.ts
@@ -80,9 +80,21 @@ export function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKey
     })
 }
 
+// Pagefind 默认标记的关键词会把附近的标点符号也匹配上，需移除
+const leadingAndTrailingPunctuationsRegexp = /^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu
 function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResult, fuzzyKeywords: FuzzyKeywords): SearchItem {
-  const route = sub?.url || result?.url
+  let route = sub?.url || result?.url
   const description = sub?.excerpt || result?.excerpt
+  const textFragment = description.match(/<mark>(.*?)<\/mark>/)?.[1]?.replace(leadingAndTrailingPunctuationsRegexp, '')
+  let routeUrl: URL | undefined
+  try {
+    routeUrl = new URL(route, location.href)
+  }
+  catch {}
+  if (textFragment && routeUrl) {
+    routeUrl.hash += `:~:text=${textFragment}`
+    route = routeUrl.href.slice(routeUrl.origin.length)
+  }
 
   // 构造标题
   // 过滤出合适的标题列表
@@ -129,8 +141,6 @@ function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResul
 const deduplicateCaseInsensitive = (arr: string[]) => [...new Map(arr.map(s => [s.toLowerCase(), s])).values()]
 type FuzzyKeywords = ReturnType<typeof extractFuzzyKeywordsFromExcerpts>
 export function extractFuzzyKeywordsFromExcerpts(results: PagefindResult[], input: string) {
-  // Pagefind 默认标记的关键词会把附近的标点符号也匹配上，需移除
-  const leadingAndTrailingPunctuationsRegexp = /^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu
   const extract = (tokens: string[]) => deduplicateCaseInsensitive(tokens.map(word =>
     word.replace(leadingAndTrailingPunctuationsRegexp, '').trim()
   ))
@@ -140,6 +150,7 @@ export function extractFuzzyKeywordsFromExcerpts(results: PagefindResult[], inpu
   }
   return Object.entries(fuzzyKeywords).flatMap(([from, keywords]) =>
     keywords.map(keyword => ({ keyword, from: from as keyof typeof fuzzyKeywords })))
+    .sort((a, b) => b.keyword.length - a.keyword.length) // 按从长到短排列
 }
 
 function markTextWithKeywords(text: string, keywords: FuzzyKeywords) {

--- a/packages/vitepress-plugin-pagefind/src/search.ts
+++ b/packages/vitepress-plugin-pagefind/src/search.ts
@@ -81,18 +81,8 @@ export function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKey
 }
 
 function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResult, fuzzyKeywords: FuzzyKeywords): SearchItem {
-  let route = sub?.url || result?.url
+  const route = sub?.url || result?.url
   const description = sub?.excerpt || result?.excerpt
-  const textFragment = description.match(/<mark>(.*?)<\/mark>/)?.[1]?.replace(leadingAndTrailingPunctuationsRegexp, '')
-  let routeUrl: URL | undefined
-  try {
-    routeUrl = new URL(route, location.href)
-  }
-  catch {}
-  if (textFragment && routeUrl) {
-    routeUrl.hash += `:~:text=${textFragment}`
-    route = routeUrl.href.slice(routeUrl.origin.length)
-  }
 
   // 构造标题
   // 过滤出合适的标题列表
@@ -137,10 +127,10 @@ function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResul
 }
 
 const deduplicateCaseInsensitive = (arr: string[]) => [...new Map(arr.map(s => [s.toLowerCase(), s])).values()]
-// Pagefind 默认标记的关键词会把附近的标点符号也匹配上，需移除
-const leadingAndTrailingPunctuationsRegexp = /^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu
 type FuzzyKeywords = ReturnType<typeof extractFuzzyKeywordsFromExcerpts>
 export function extractFuzzyKeywordsFromExcerpts(results: PagefindResult[], input: string) {
+  // Pagefind 默认标记的关键词会把附近的标点符号也匹配上，需移除
+  const leadingAndTrailingPunctuationsRegexp = /^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu
   const extract = (tokens: string[]) => deduplicateCaseInsensitive(tokens.map(word =>
     word.replace(leadingAndTrailingPunctuationsRegexp, '').trim()
   ))
@@ -172,16 +162,4 @@ function markTextWithKeywords(text: string, keywords: FuzzyKeywords) {
     }
   }
   return segments.map(segment => typeof segment === 'string' ? segment : `<mark>${segment.mark}</mark>`).join('')
-}
-
-function getTextFragmentFromExcerpt(excerpt: string) {
-  const MARK_ON = '<mark>'
-  const MARK_OFF = '</mark>'
-  const indexBeforeMarkOn = excerpt.indexOf(MARK_ON)
-  const indexBeforeMarkOff = excerpt.indexOf(MARK_OFF)
-  const indexAfterMarkOn = indexBeforeMarkOn + MARK_ON.length
-  const indexAfterMarkOff = indexBeforeMarkOff + MARK_OFF.length
-  const text = excerpt.slice(indexAfterMarkOn, indexBeforeMarkOff)
-  const beforeText = excerpt.slice(0, indexBeforeMarkOn).replaceAll(MARK_ON, '').replaceAll(MARK_OFF, '').trimEnd()
-  const afterText = excerpt.slice(indexAfterMarkOff).replaceAll(MARK_ON, '').replaceAll(MARK_OFF, '').trimStart()
 }

--- a/packages/vitepress-plugin-pagefind/src/search.ts
+++ b/packages/vitepress-plugin-pagefind/src/search.ts
@@ -1,50 +1,4 @@
-interface PagefindResult {
-  url: string
-  content: string
-  word_count: number
-  filters: Filters
-  meta: Meta
-  anchors: Anchor[]
-  weighted_locations: WeightedLocation[]
-  locations: number[]
-  raw_content: string
-  raw_url: string
-  excerpt: string
-  sub_results: SubResult[]
-}
-
-interface SubResult {
-  title: string
-  url: string
-  anchor: Anchor
-  weighted_locations: WeightedLocation[]
-  locations: number[]
-  excerpt: string
-}
-
-interface WeightedLocation {
-  weight: number
-  balanced_score: number
-  location: number
-}
-
-interface Anchor {
-  element: string
-  id: string
-  text: string
-  location: number
-}
-
-interface Meta {
-  image_alt: string
-  title: string
-  image: string
-  base64: string
-  date?: string
-}
-
-interface Filters {
-}
+import type { Anchor, PagefindResult, SearchItem, SubResult } from './type'
 
 function decodeBase64AndDeserialize(base64String: string) {
   if (!base64String) {
@@ -60,7 +14,7 @@ function decodeBase64AndDeserialize(base64String: string) {
   }
 }
 
-export function formatPagefindResult(result: PagefindResult, count = 1) {
+export function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKeywords: string[] = []) {
   const { sub_results: subResults, anchors, weighted_locations: weightedLocations } = result
   // TODO：pick策略优化
   // 按照权重排序，从大到小
@@ -115,18 +69,18 @@ export function formatPagefindResult(result: PagefindResult, count = 1) {
     return minA - minB
   })
 
-  const filterMap = new Map<string, any>()
-  return subs.map(sub => parseSubResult(sub, anchors, result))
+  const filterSet = new Set<string>()
+  return subs.map(sub => parseSubResult(sub, anchors, result, fuzzyKeywords))
     .filter((v) => {
-      if (filterMap.has(v.meta.title)) {
+      const title = v.meta.title.join(' > ')
+      if (filterSet.has(title))
         return false
-      }
-      filterMap.set(v.meta.title, v)
+      filterSet.add(title)
       return true
     })
 }
 
-function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResult) {
+function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResult, fuzzyKeywords: string[] = []): SearchItem {
   const route = sub?.url || result?.url
   const description = sub?.excerpt || result?.excerpt
 
@@ -154,18 +108,53 @@ function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResul
     return prev
   }, [] as Anchor[])
   // 构造完整的 title 层级 信息
-  const title = filteredAnchors.length ? filteredAnchors.map(t => t.text.trim()).filter(v => !!v).join(' > ') : result.meta.title
+  const title = filteredAnchors.length
+    ? filteredAnchors.map(t => markTextWithKeywords(t.text.trim(), fuzzyKeywords)).filter(Boolean)
+    : [markTextWithKeywords(result.meta.title, fuzzyKeywords)]
 
   const { base64, date, ...otherMeta } = result.meta
   return {
     route,
     meta: {
       date: date ? +date : undefined,
-      ...decodeBase64AndDeserialize(base64),
+      ...decodeBase64AndDeserialize(base64) as object,
       ...otherMeta,
       title,
       description,
     },
     result
   }
+}
+
+const deduplicateCaseInsensitive = (arr: string[]) => [...new Map(arr.map(s => [s.toLowerCase(), s])).values()]
+
+export function extractFuzzyKeywordsFromExcerpts(results: PagefindResult[], input: string) {
+  // Pagefind 默认标记的关键词会把附近的标点符号也匹配上，需移除
+  const leadingAndTrailingPunctuationsRegexp = /^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu
+  return deduplicateCaseInsensitive(results.flatMap(result =>
+    [
+      ...result.excerpt.matchAll(/<mark>(.+?)<\/mark>/g).map(matched => matched[1]),
+      ...input.trim().split(/\s/),
+    ].map(word => word.replace(leadingAndTrailingPunctuationsRegexp, '').trim())
+  )).sort((a, b) => b.length - a.length) // 按从长到短排列
+}
+
+function markTextWithKeywords(text: string, keywords: string[]) {
+  if (!text)
+    return text
+  text = text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  const segments: (string | { mark: string })[] = [text]
+  for (const keyword of keywords) {
+    const regexp = new RegExp('escape' in RegExp ? RegExp.escape(keyword) : keyword, 'gi')
+    for (let i = segments.length - 1; i >= 0; i--) {
+      const segment = segments[i]
+      if (typeof segment !== 'string' || segment === '') // 如果 keywords 中包含空字符串（''），正则 gi 会导致死循环（无限匹配）
+        continue
+      if (regexp.test(segment)) {
+        const splitted = segment.split(regexp).flatMap((seg, i) => i ? [{ mark: segment.match(regexp)![i - 1] }, seg] : [seg])
+        segments.splice(i, 1, ...splitted)
+      }
+    }
+  }
+  return segments.map(segment => typeof segment === 'string' ? segment : `<mark>${segment.mark}</mark>`).join('')
 }

--- a/packages/vitepress-plugin-pagefind/src/search.ts
+++ b/packages/vitepress-plugin-pagefind/src/search.ts
@@ -80,8 +80,6 @@ export function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKey
     })
 }
 
-// Pagefind 默认标记的关键词会把附近的标点符号也匹配上，需移除
-const leadingAndTrailingPunctuationsRegexp = /^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu
 function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResult, fuzzyKeywords: FuzzyKeywords): SearchItem {
   let route = sub?.url || result?.url
   const description = sub?.excerpt || result?.excerpt
@@ -139,6 +137,8 @@ function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResul
 }
 
 const deduplicateCaseInsensitive = (arr: string[]) => [...new Map(arr.map(s => [s.toLowerCase(), s])).values()]
+// Pagefind 默认标记的关键词会把附近的标点符号也匹配上，需移除
+const leadingAndTrailingPunctuationsRegexp = /^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu
 type FuzzyKeywords = ReturnType<typeof extractFuzzyKeywordsFromExcerpts>
 export function extractFuzzyKeywordsFromExcerpts(results: PagefindResult[], input: string) {
   const extract = (tokens: string[]) => deduplicateCaseInsensitive(tokens.map(word =>
@@ -172,4 +172,16 @@ function markTextWithKeywords(text: string, keywords: FuzzyKeywords) {
     }
   }
   return segments.map(segment => typeof segment === 'string' ? segment : `<mark>${segment.mark}</mark>`).join('')
+}
+
+function getTextFragmentFromExcerpt(excerpt: string) {
+  const MARK_ON = '<mark>'
+  const MARK_OFF = '</mark>'
+  const indexBeforeMarkOn = excerpt.indexOf(MARK_ON)
+  const indexBeforeMarkOff = excerpt.indexOf(MARK_OFF)
+  const indexAfterMarkOn = indexBeforeMarkOn + MARK_ON.length
+  const indexAfterMarkOff = indexBeforeMarkOff + MARK_OFF.length
+  const text = excerpt.slice(indexAfterMarkOn, indexBeforeMarkOff)
+  const beforeText = excerpt.slice(0, indexBeforeMarkOn).replaceAll(MARK_ON, '').replaceAll(MARK_OFF, '').trimEnd()
+  const afterText = excerpt.slice(indexAfterMarkOff).replaceAll(MARK_ON, '').replaceAll(MARK_OFF, '').trimStart()
 }

--- a/packages/vitepress-plugin-pagefind/src/search.ts
+++ b/packages/vitepress-plugin-pagefind/src/search.ts
@@ -14,7 +14,7 @@ function decodeBase64AndDeserialize(base64String: string) {
   }
 }
 
-export function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKeywords: string[] = []) {
+export function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKeywords: FuzzyKeywords) {
   const { sub_results: subResults, anchors, weighted_locations: weightedLocations } = result
   // TODO：pick策略优化
   // 按照权重排序，从大到小
@@ -80,7 +80,7 @@ export function formatPagefindResult(result: PagefindResult, count = 1, fuzzyKey
     })
 }
 
-function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResult, fuzzyKeywords: string[] = []): SearchItem {
+function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResult, fuzzyKeywords: FuzzyKeywords): SearchItem {
   const route = sub?.url || result?.url
   const description = sub?.excerpt || result?.excerpt
 
@@ -127,25 +127,28 @@ function parseSubResult(sub: SubResult, anchors: Anchor[], result: PagefindResul
 }
 
 const deduplicateCaseInsensitive = (arr: string[]) => [...new Map(arr.map(s => [s.toLowerCase(), s])).values()]
-
+type FuzzyKeywords = ReturnType<typeof extractFuzzyKeywordsFromExcerpts>
 export function extractFuzzyKeywordsFromExcerpts(results: PagefindResult[], input: string) {
   // Pagefind 默认标记的关键词会把附近的标点符号也匹配上，需移除
   const leadingAndTrailingPunctuationsRegexp = /^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu
-  return deduplicateCaseInsensitive(results.flatMap(result =>
-    [
-      ...result.excerpt.matchAll(/<mark>(.+?)<\/mark>/g).map(matched => matched[1]),
-      ...input.trim().split(/\s/),
-    ].map(word => word.replace(leadingAndTrailingPunctuationsRegexp, '').trim())
-  )).sort((a, b) => b.length - a.length) // 按从长到短排列
+  const extract = (tokens: string[]) => deduplicateCaseInsensitive(tokens.map(word =>
+    word.replace(leadingAndTrailingPunctuationsRegexp, '').trim()
+  ))
+  return {
+    excerptWords: extract(results.flatMap(result => [...result.excerpt.matchAll(/<mark>(.+?)<\/mark>/g).map(matched => matched[1])])),
+    inputTokens: extract(input.trim().split(/\s/)),
+  }
 }
 
-function markTextWithKeywords(text: string, keywords: string[]) {
+function markTextWithKeywords(text: string, fuzzyKeywords: FuzzyKeywords) {
   if (!text)
     return text
   text = text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
   const segments: (string | { mark: string })[] = [text]
-  for (const keyword of keywords) {
-    const regexp = new RegExp('escape' in RegExp ? RegExp.escape(keyword) : keyword, 'gi')
+  const keywords = Object.entries(fuzzyKeywords).flatMap(([from, keywords]) => keywords.map(keyword => ({ keyword, from })))
+  for (const { keyword, from } of keywords) {
+    const escapedKeyword = 'escape' in RegExp ? RegExp.escape(keyword) : keyword
+    const regexp = new RegExp(from === 'excerptWords' ? `\\b${escapedKeyword}\\b` : escapedKeyword, 'gi')
     for (let i = segments.length - 1; i >= 0; i--) {
       const segment = segments[i]
       if (typeof segment !== 'string' || segment === '') // 如果 keywords 中包含空字符串（''），正则 gi 会导致死循环（无限匹配）

--- a/packages/vitepress-plugin-pagefind/src/type.ts
+++ b/packages/vitepress-plugin-pagefind/src/type.ts
@@ -77,6 +77,7 @@ export interface SearchItem {
   }>
   result: PagefindResult
 }
+
 export interface SearchConfig {
   /**
    * @default

--- a/packages/vitepress-plugin-pagefind/src/type.ts
+++ b/packages/vitepress-plugin-pagefind/src/type.ts
@@ -134,6 +134,12 @@ export interface SearchConfig {
    * 'Reset search'
    */
   resetSearch?: string
+  /**
+   * This label is only displayed in the mobile view.
+   * @default
+   * 'Close search'
+   */
+  closeSearch?: string
 
   /**
    * Automatically reloads the page when the page language changes.

--- a/packages/vitepress-plugin-pagefind/src/type.ts
+++ b/packages/vitepress-plugin-pagefind/src/type.ts
@@ -215,6 +215,12 @@ export interface SearchConfig {
    * @default false
    */
   mpaDefaultUI?: boolean
+
+  /**
+   * Clear the search content and results when the search dialog is closed
+   * @default false
+   */
+  clearWhenClosed?: boolean
 }
 
 export type PagefindConfig = PagefindOption & SearchConfig

--- a/packages/vitepress-plugin-pagefind/src/type.ts
+++ b/packages/vitepress-plugin-pagefind/src/type.ts
@@ -40,6 +40,8 @@ interface Meta {
   title: string
   image: string
   base64: string
+  date?: number
+  description?: string
 }
 
 interface Filters {

--- a/packages/vitepress-plugin-pagefind/src/type.ts
+++ b/packages/vitepress-plugin-pagefind/src/type.ts
@@ -220,6 +220,7 @@ export interface SearchConfig {
    * Clear the search content and results when the search dialog is closed
    *
    * - `'never'`: Never clear search content and results when closed
+   *   - Same as `'visit'` in MPA mode
    * - `'always'`: Always clear search content and results when closed
    * - `'visit'`: Clear search content and results only if user select a search result link,
    * and won't clear if user just close the dialog directly

--- a/packages/vitepress-plugin-pagefind/src/type.ts
+++ b/packages/vitepress-plugin-pagefind/src/type.ts
@@ -218,9 +218,15 @@ export interface SearchConfig {
 
   /**
    * Clear the search content and results when the search dialog is closed
-   * @default false
+   *
+   * - `'never'`: Never clear search content and results when closed
+   * - `'always'`: Always clear search content and results when closed
+   * - `'visit'`: Clear search content and results only if user select a search result link,
+   * and won't clear if user just close the dialog directly
+   *
+   * @default 'never'
    */
-  clearWhenClosed?: boolean
+  clearWhenClosed?: 'never' | 'always' | 'visit'
 }
 
 export type PagefindConfig = PagefindOption & SearchConfig

--- a/packages/vitepress-plugin-pagefind/src/type.ts
+++ b/packages/vitepress-plugin-pagefind/src/type.ts
@@ -13,7 +13,7 @@ export interface PagefindResult {
   sub_results: SubResult[]
 }
 
-interface SubResult {
+export interface SubResult {
   title: string
   url: string
   anchor: Anchor
@@ -22,26 +22,27 @@ interface SubResult {
   excerpt: string
 }
 
-interface WeightedLocation {
+export interface WeightedLocation {
   weight: number
   balanced_score: number
   location: number
 }
 
-interface Anchor {
+export interface Anchor {
   element: string
   id: string
   text: string
   location: number
 }
 
-interface Meta {
+export interface Meta {
   image_alt: string
   title: string
   image: string
   base64: string
-  date?: number
+  date?: string
   description?: string
+  publish?: boolean
 }
 
 interface Filters {
@@ -70,7 +71,10 @@ export interface PagefindOption {
 
 export interface SearchItem {
   route: string
-  meta: Record<string, any>
+  meta: Override<Omit<Partial<Meta>, 'base64'>, {
+    date?: number
+    title: string[]
+  }>
   result: PagefindResult
 }
 export interface SearchConfig {
@@ -231,3 +235,5 @@ export interface SearchConfig {
 }
 
 export type PagefindConfig = PagefindOption & SearchConfig
+
+type Override<T, U> = Omit<T, keyof U> & U

--- a/packages/vitepress-plugin-pagefind/src/types/global.d.ts
+++ b/packages/vitepress-plugin-pagefind/src/types/global.d.ts
@@ -1,0 +1,9 @@
+declare module 'virtual:pagefind' {
+  export const searchConfig: import('../type').SearchConfig
+}
+
+declare interface Window {
+  __pagefind__?: import('./pagefind').Pagefind
+  PagefindUI?: typeof import('./pagefind').PagefindUI
+  pagefindInitialized?: boolean
+}

--- a/packages/vitepress-plugin-pagefind/src/types/pagefind.d.ts
+++ b/packages/vitepress-plugin-pagefind/src/types/pagefind.d.ts
@@ -1,3 +1,5 @@
+import type { PagefindResult } from '../type'
+
 export interface PagefindIndexOptions {
   basePath?: string
   baseUrl?: string
@@ -42,7 +44,7 @@ export interface PagefindSearchResult {
   id: string
   score: number
   words: number[]
-  data: () => Promise<PagefindSearchFragment>
+  data: () => Promise<PagefindResult>
 }
 
 export interface PagefindSearchFragment {

--- a/packages/vitepress-plugin-pagefind/src/types/pagefind.d.ts
+++ b/packages/vitepress-plugin-pagefind/src/types/pagefind.d.ts
@@ -1,0 +1,112 @@
+export interface PagefindIndexOptions {
+  basePath?: string
+  baseUrl?: string
+  excerptLength?: number
+  indexWeight?: number
+  mergeFilter?: Record<string, unknown>
+  highlightParam?: string
+  language?: string
+  primary?: boolean
+  ranking?: PagefindRankingWeights
+}
+
+export interface PagefindRankingWeights {
+  termSimilarity?: number
+  pageLength?: number
+  termSaturation?: number
+  termFrequency?: number
+}
+
+export interface PagefindSearchOptions {
+  preload?: boolean
+  verbose?: boolean
+  filters?: Record<string, unknown>
+  sort?: Record<string, unknown>
+}
+
+export interface PagefindFilterCounts extends Record<string, Record<string, number>> {}
+
+export interface PagefindSearchResults {
+  results: PagefindSearchResult[]
+  unfilteredResultCount: number
+  filters: PagefindFilterCounts
+  totalFilters: PagefindFilterCounts
+  timings: {
+    preload: number
+    search: number
+    total: number
+  }
+}
+
+export interface PagefindSearchResult {
+  id: string
+  score: number
+  words: number[]
+  data: () => Promise<PagefindSearchFragment>
+}
+
+export interface PagefindSearchFragment {
+  url: string
+  raw_url?: string
+  content: string
+  raw_content?: string
+  excerpt: string
+  sub_results: PagefindSubResult[]
+  word_count: number
+  locations: number[]
+  weighted_locations: PagefindWordLocation[]
+  filters: Record<string, string[]>
+  meta: Record<string, string>
+  anchors: PagefindSearchAnchor[]
+}
+
+export interface PagefindSubResult {
+  title: string
+  url: string
+  locations: number[]
+  weighted_locations: PagefindWordLocation[]
+  excerpt: string
+  anchor?: PagefindSearchAnchor
+}
+
+export interface PagefindWordLocation {
+  weight: number
+  balanced_score: number
+  location: number
+}
+
+export interface PagefindSearchAnchor {
+  element: string
+  id: string
+  text?: string
+  location: number
+}
+
+export interface Pagefind {
+  debouncedSearch: (
+    query: string,
+    options?: PagefindSearchOptions,
+    duration?: number,
+  ) => Promise<PagefindSearchResults>
+  destroy: () => Promise<void>
+  filters: () => Promise<PagefindFilterCounts>
+  init: () => Promise<void>
+  mergeIndex: (indexPath: string, options?: Record<string, unknown>) => Promise<void>
+  options: (options: PagefindIndexOptions) => Promise<void>
+  preload: (term: string, options?: PagefindIndexOptions) => Promise<void>
+  search: (term: string | null, options?: PagefindSearchOptions) => Promise<PagefindSearchResults>
+}
+
+export interface PagefindUIOptions {
+  element: string
+  showSubResults: boolean
+  showImages: boolean
+  translations: {
+    placeholder: string
+  }
+}
+
+// eslint-disable-next-line ts/no-extraneous-class
+export declare class PagefindUI {
+  constructor(options: PagefindUIOptions)
+}

--- a/packages/vitepress-plugin-pagefind/src/utils/index.ts
+++ b/packages/vitepress-plugin-pagefind/src/utils/index.ts
@@ -1,78 +1,36 @@
-export function formatDate(d: any, fmt = 'yyyy-MM-dd hh:mm:ss') {
-  if (!(d instanceof Date)) {
-    d = new Date(d)
+export function formatDate(date: Date | string, lang: string) {
+  if (!(date instanceof Date)) {
+    date = new Date(date)
   }
-  const o: any = {
-    'M+': d.getMonth() + 1, // 月份
-    'd+': d.getDate(), // 日
-    'h+': d.getHours(), // 小时
-    'm+': d.getMinutes(), // 分
-    's+': d.getSeconds(), // 秒
-    'q+': Math.floor((d.getMonth() + 3) / 3), // 季度
-    'S': d.getMilliseconds() // 毫秒
-  }
-  if (/(y+)/.test(fmt)) {
-    fmt = fmt.replace(
-      RegExp.$1,
-      `${d.getFullYear()}`.substr(4 - RegExp.$1.length)
-    )
-  }
-  // eslint-disable-next-line no-restricted-syntax
-  for (const k in o) {
-    if (new RegExp(`(${k})`).test(fmt))
-      fmt = fmt.replace(
-        RegExp.$1,
-        RegExp.$1.length === 1 ? o[k] : `00${o[k]}`.substr(`${o[k]}`.length)
-      )
-  }
-  return fmt
+
+  return new Intl.DateTimeFormat(lang, { year: 'numeric', month: '2-digit', day: '2-digit' }).format(date)
 }
 
 export function formatShowDate(date: Date | string, lang: string) {
   const source = +new Date(date)
   const now = +new Date()
-  const diff = now - source
+  const diff = source - now
+
   const oneSeconds = 1000
   const oneMinute = oneSeconds * 60
   const oneHour = oneMinute * 60
   const oneDay = oneHour * 24
   const oneWeek = oneDay * 7
 
-  const langMap = {
-    'zh-cn': {
-      justNow: '刚刚',
-      secondsAgo: '秒前',
-      minutesAgo: '分钟前',
-      hoursAgo: '小时前',
-      daysAgo: '天前',
-      weeksAgo: '周前'
-    },
-    'en-us': {
-      justNow: ' just now',
-      secondsAgo: ' seconds ago',
-      minutesAgo: ' minutes ago',
-      hoursAgo: ' hours ago',
-      daysAgo: ' days ago',
-      weeksAgo: ' weeks ago'
-    }
-  }
-  const mapValue = langMap[lang.toLowerCase() as 'zh-cn' | 'en-us'] || langMap['en-us']
+  const formatter = new Intl.RelativeTimeFormat(lang, { style: 'long', numeric: 'auto' })
 
-  if (diff < 10) {
-    return mapValue.justNow
+  if (Math.abs(diff) < oneMinute) {
+    return formatter.format(Math.trunc(diff / oneSeconds), 'second')
   }
-  if (diff < oneMinute) {
-    return `${Math.floor(diff / oneSeconds)}${mapValue.secondsAgo}`
+  if (Math.abs(diff) < oneHour) {
+    return formatter.format(Math.trunc(diff / oneMinute), 'minute')
   }
-  if (diff < oneHour) {
-    return `${Math.floor(diff / oneMinute)}${mapValue.minutesAgo}`
+  if (Math.abs(diff) < oneDay) {
+    return formatter.format(Math.trunc(diff / oneHour), 'hour')
   }
-  if (diff < oneDay) {
-    return `${Math.floor(diff / oneHour)}${mapValue.hoursAgo}`
-  }
-  if (diff < oneWeek) {
-    return `${Math.floor(diff / oneDay)}${mapValue.daysAgo}`
+  if (Math.abs(diff) < oneWeek) {
+    return formatter.format(Math.trunc(diff / oneDay), 'day')
   }
 
-  return formatDate(new Date(date), 'yyyy-MM-dd')
+  return formatDate(new Date(date), lang)
 }

--- a/packages/vitepress-plugin-pagefind/tsconfig.json
+++ b/packages/vitepress-plugin-pagefind/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "baseUrl": ".",
+    "types": ["vite/client"],
     "resolveJsonModule": true,
     "allowJs": true,
     "outDir": "dist",


### PR DESCRIPTION
本次pr未进行版本号的更新，因为我看到之前你有一个“撤回手动版本号bump，交由维护者走changeset发版”的提交，因此我没有手动更新版本号。

改动内容：

### `vitepress-plugin-back2top` & `vitepress-plugin-artalk` & `vitepress-plugin-giscus`

* 之前的按钮 box-shadow 效果我还是不太满意，因为在按钮本身为主题色着色的情况下，阴影却用的是纯黑色，看起来非常不自然。因此我改成了基于主题色的调色。即比主题色黑，但不是纯黑。
* 修复当浏览器支持 backdrop-filter 的情况下，悬停按钮没有半透明变化的过渡效果。

> 注：在之前的pr #454 中，本来我有一段 `@supports (color: rgb(from red r g b / 1))` 的代码，被你后来改成 `@supports (backdrop-filter: blur(3px))` 了，并删除了后续 `:is(.icon-wrapper, .icon-wrapper-text):not(:hover):not(:active)` 的样式。你可能误解了我的意思。
>
> 若要实现 `backdrop-filter: blur()`，不能使用opacity来控制不透明度，否则背景的模糊也会被显示出来。
> 因此必须固定 `opacity: 1`。然后只能通过控制更改按钮的背景色和前景色来设置颜色。
> 为保证颜色与用户自定义的品牌颜色匹配，需要用到相对颜色语法来计算特定颜色。
> 若浏览器已支持相对颜色语法特性，此时也一定支持 `backdrop-filter` 属性和 `oklch()` 颜色空间，无需特意额外声明检查支持性。

### `vitepress-plugin-image-preview`

* 调整禁用按钮的样式，当按钮禁用时保留背景亚克力效果。
* 调整进度数字为等宽数字（等宽数字不是指等宽字体！）。避免在翻页时，数字位置会产生细微的偏移。
  例如1/2变成2/2时，由于2看起来比1宽，导致斜杠及右边的数字部分会略微往右移动。

### `vitepress-plugin-pagefind`

这是本次更新的重点。

* 新增插件选项 `closeSearch`：用于控制移动端搜索界面左上角“关闭搜索”按钮的工具提示。
* 新增插件选项 `clearWhenClosed`: 允许自定义当搜索对话框关闭后，下次打开时是否显示之前搜索的内容。
  原本的行为是关闭搜索对话框后，下次打开搜索，搜索的文本内容会被清除，但搜索结果依然保留，非常奇怪。
  现在支持以下配置选项：

  - `'never'`: 关闭搜索对话框后，从不自动清除搜索内容和结果。
  - `'always'`: 关闭搜索对话框后，总是自动清除搜索内容和结果。
  - `'visit'`: 当用户点击访问一个搜索结果的链接后，才会自动清除搜索内容和结果。如果只是直接关闭搜索对话框，则不会自动清除搜索内容和结果。
  
  注意：当开启MPA模式后，由于跳转到链接必定会触发网页重载。因此在MPA模式中，使用never和使用visit没有区别。
  默认：never

* 新增在搜索结果的标题中也包含关键词的高亮。
* 在议题 #455 中，新增当搜索中时改为显示“搜索中”，未搜索时不显示内容，而之前的行为是无论如何都会显示“空空如也”。
  但我发现在未搜索时只有一个搜索框，感觉太空了。后面发现VitePress自带的搜索不管是local search还是algolia search，在未搜索时会保留底栏，因此我也让它保留了底栏。
* 修复从“搜索中”提示到出现搜索结果的过渡期间没有高度过渡动画。
* 修复在未搜索状态下第一次执行搜索时不显示搜索条数的字样，其实是因为被滚动到界面外面去了。
* 修复在SSR水合期间，搜索快捷键会短暂显示为K，然后突然变回Ctrl+K。
* 重磅更新！在切换语言后，无需重载网页即可立即进行新语言的搜索。
* 将 formatShowDate 和 formatDate 函数改为现代的获取日期方式，支持世界上的所有语言，不仅限于中英文了。
  * 因此 showDate 插件选项手动传入回调函数意义不大了，直接传布尔值就好了。
  * formatDate 的本地化可以支持不同地区的年月日顺序，例如中文为年月日，英文为月日年，等等。
  * formatShowDate 的本地化理论上可以支持更高的相对日期，例如“一周前”“一个月前”“一个季度前”“一年前”，但是感觉意义不大，尤其是当看到“三个月前”的字样却不知道具体是三个月前的哪一天时非常苦恼。因此我保留了插件原本的行为，即超过一周后显示绝对日期。
* 移除代码中所有的 @ts-expect-error，全部按照正确遵循 TypeScript 的方式编写。
* 修复 SearchMPA 和 SearchMPADefault 的所有 ESLint 报错与 TypeScript 报错。
* 然后我发现原来 `<script client>` 不支持写 TypeScript，白修了，但我不想白修，因此添加了自动转换 `<script client lang="ts">` 回 `<script client lang="js">` 的构建流程。

## 其它东西

* 原本还尝试添加[文本片段高亮](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments)的功能，可以实现搜索后直接滚动到正文内容的功能。但是pagefind本身返回的excerpt内容太诡异了，做了很多多余的改动。导致实现起来非常困难。我只好回滚了这个功能，并向pagefind提了一个议题看看他们如何解决。等下次再研究这个问题吧。
* 永远不要使用 `/[\u4E00-\u9FA5]/` 来匹配汉字！请使用 `/\p{Ideo}/u` 或 `/\p{UIdeo}/u` ！